### PR TITLE
Implement adding null check for this call

### DIFF
--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3332,31 +4165,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3429,7 +4281,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -3575,6 +4461,26 @@ INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -3710,4 +4616,6 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3336,31 +4169,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3433,7 +4285,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4202,6 +5088,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4337,6 +5243,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3325,31 +4158,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3422,7 +4274,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4191,6 +5077,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4326,6 +5232,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3323,31 +4156,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3420,7 +4272,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4189,6 +5075,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4324,6 +5230,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3340,31 +4173,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3437,7 +4289,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4206,6 +5092,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4341,6 +5247,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3356,31 +4189,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3453,7 +4305,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4222,6 +5108,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4357,6 +5263,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3353,31 +4186,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3450,7 +4302,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4219,6 +5105,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4354,6 +5260,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3342,31 +4175,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3439,7 +4291,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4208,6 +5094,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4343,6 +5249,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3358,31 +4191,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3455,7 +4307,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4224,6 +5110,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4359,6 +5265,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3336,31 +4169,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3433,7 +4285,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4202,6 +5088,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4337,6 +5243,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3325,31 +4158,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3422,7 +4274,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4191,6 +5077,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4326,6 +5232,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3336,31 +4169,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3433,7 +4285,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4202,6 +5088,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4337,6 +5243,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3335,31 +4168,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3432,7 +4284,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4201,6 +5087,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4336,6 +5242,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -2535,7 +3368,7 @@ Failed to read String.Concat[Tail call]
 INFO:  jitting method Double::ToString using LLILCJit
 Failed to read Double.ToString[Tail call]
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
-Failed to read NumberFormatInfo.get_CurrentInfo[Call needs null check]
+Failed to read NumberFormatInfo.get_CurrentInfo[convertHandle]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4145,31 +4978,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4242,7 +5094,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit
 Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -4304,6 +5190,26 @@ INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4439,4 +5345,6 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3336,31 +4169,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3433,7 +4285,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4202,6 +5088,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4337,6 +5243,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3339,31 +4172,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3436,7 +4288,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4205,6 +5091,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4340,6 +5246,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3336,31 +4169,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3433,7 +4285,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4202,6 +5088,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4337,6 +5243,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3325,31 +4158,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3422,7 +4274,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4191,6 +5077,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4326,6 +5232,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3323,31 +4156,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3420,7 +4272,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4189,6 +5075,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4324,6 +5230,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3340,31 +4173,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3437,7 +4289,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4206,6 +5092,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4341,6 +5247,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3356,31 +4189,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3453,7 +4305,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4222,6 +5108,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4357,6 +5263,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3353,31 +4186,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3450,7 +4302,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4219,6 +5105,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4354,6 +5260,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3342,31 +4175,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3439,7 +4291,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4208,6 +5094,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4343,6 +5249,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3384,31 +4217,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3481,7 +4333,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4250,6 +5136,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4385,6 +5291,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3388,31 +4221,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3485,7 +4337,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4254,6 +5140,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4389,6 +5295,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3384,31 +4217,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3481,7 +4333,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4250,6 +5136,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4385,6 +5291,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3323,31 +4156,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3420,7 +4272,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4189,6 +5075,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4324,6 +5230,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3336,31 +4169,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3433,7 +4285,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4202,6 +5088,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4337,6 +5243,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3340,31 +4173,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3437,7 +4289,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4206,6 +5092,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4341,6 +5247,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3325,31 +4158,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3422,7 +4274,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4191,6 +5077,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4326,6 +5232,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3325,31 +4158,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3422,7 +4274,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4191,6 +5077,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4326,6 +5232,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3336,31 +4169,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3433,7 +4285,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4202,6 +5088,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4337,6 +5243,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3335,31 +4168,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3432,7 +4284,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4201,6 +5087,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4336,6 +5242,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3323,31 +4156,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3420,7 +4272,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4189,6 +5075,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4324,6 +5230,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -4333,7 +5241,7 @@ Failed to read String.Concat[Tail call]
 INFO:  jitting method Single::ToString using LLILCJit
 Failed to read Single.ToString[Tail call]
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
-Failed to read NumberFormatInfo.get_CurrentInfo[Call needs null check]
+Failed to read NumberFormatInfo.get_CurrentInfo[convertHandle]
 INFO:  jitting method String::ToString using LLILCJit
 Successfully read String.ToString
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3351,31 +4184,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3448,7 +4300,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4217,6 +5103,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4352,6 +5258,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3336,31 +4169,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3433,7 +4285,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4202,6 +5088,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4337,6 +5243,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3333,31 +4166,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3430,7 +4282,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4199,6 +5085,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4334,6 +5240,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3339,31 +4172,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3436,7 +4288,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4205,6 +5091,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4340,6 +5246,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3370,31 +4203,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3467,7 +4319,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4236,6 +5122,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4371,6 +5277,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -2595,7 +3428,7 @@ entry:
 INFO:  jitting method Int32::ToString using LLILCJit
 Failed to read Int32.ToString[Tail call]
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
-Failed to read NumberFormatInfo.get_CurrentInfo[Call needs null check]
+Failed to read NumberFormatInfo.get_CurrentInfo[convertHandle]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4096,31 +4929,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4193,7 +5045,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit
 Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -4255,6 +5141,26 @@ INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4390,6 +5296,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method String::Concat using LLILCJit
 Failed to read String.Concat[Tail call]
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,11 +3356,11 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
-Failed to read BringUpTest.Main[Call needs null check]
+Failed to read BringUpTest.Main[convertHandle]
 INFO:  jitting method MiscMethods::.ctor using LLILCJit
 Successfully read MiscMethods..ctor
 
@@ -2588,7 +3421,62 @@ entry:
 }
 
 INFO:  jitting method BringUpTest::InstanceCalls using LLILCJit
-Failed to read BringUpTest.InstanceCalls[Call needs null check]
+Successfully read BringUpTest.InstanceCalls
+
+define i32 @BringUpTest.InstanceCalls(%MiscMethods addrspace(1)* %param0, %"System.Int32[]" addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %MiscMethods addrspace(1)*
+  %arg1 = alloca %"System.Int32[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  store %MiscMethods addrspace(1)* %param0, %MiscMethods addrspace(1)** %arg0
+  store %"System.Int32[]" addrspace(1)* %param1, %"System.Int32[]" addrspace(1)** %arg1
+  store i32 100, i32* %loc0
+  %0 = load %MiscMethods addrspace(1)** %arg0
+  %1 = load %"System.Int32[]" addrspace(1)** %arg1
+  %NullCheck = icmp ne %MiscMethods addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%MiscMethods addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%MiscMethods addrspace(1)* %0, %"System.Int32[]" addrspace(1)* %1)
+  store i32 %3, i32* %loc1
+  %4 = load i32* %loc1
+  %5 = icmp eq i32 %4, 15
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %2
+  store i32 -1, i32* %loc0
+  br label %7
+
+; <label>:7                                       ; preds = %2, %6
+  %8 = load %MiscMethods addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %7
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%MiscMethods addrspace(1)*, i32, i32, i32, i32, i32)*)(%MiscMethods addrspace(1)* %8, i32 1, i32 2, i32 3, i32 4, i32 5)
+  store i32 %10, i32* %loc1
+  %11 = load i32* %loc1
+  %12 = icmp eq i32 %11, 15
+  br i1 %12, label %14, label %13
+
+; <label>:13                                      ; preds = %9
+  store i32 -1, i32* %loc0
+  br label %14
+
+; <label>:14                                      ; preds = %9, %13
+  %15 = load i32* %loc0
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method MiscMethods::Sum using LLILCJit
 Failed to read MiscMethods.Sum[loadElem]
 INFO:  jitting method MiscMethods::Sum using LLILCJit
@@ -2621,7 +3509,66 @@ entry:
 }
 
 INFO:  jitting method BringUpTest::InstanceCalls using LLILCJit
-Failed to read BringUpTest.InstanceCalls[Call needs null check]
+Successfully read BringUpTest.InstanceCalls
+
+define i32 @BringUpTest.InstanceCalls(%MiscMethods addrspace(1)* %param0, %"System.Single[]" addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %MiscMethods addrspace(1)*
+  %arg1 = alloca %"System.Single[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca float
+  store %MiscMethods addrspace(1)* %param0, %MiscMethods addrspace(1)** %arg0
+  store %"System.Single[]" addrspace(1)* %param1, %"System.Single[]" addrspace(1)** %arg1
+  store i32 100, i32* %loc0
+  %0 = load %MiscMethods addrspace(1)** %arg0
+  %1 = load %"System.Single[]" addrspace(1)** %arg1
+  %NullCheck = icmp ne %MiscMethods addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (%MiscMethods addrspace(1)*, %"System.Single[]" addrspace(1)*)*)(%MiscMethods addrspace(1)* %0, %"System.Single[]" addrspace(1)* %1)
+  store float %3, float* %loc1
+  %4 = load float* %loc1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %4, float 1.500000e+01)
+  %6 = zext i8 %5 to i32
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %2
+  store i32 -1, i32* %loc0
+  br label %9
+
+; <label>:9                                       ; preds = %2, %8
+  %10 = load %MiscMethods addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (%MiscMethods addrspace(1)*, float, float, float, float, float)*)(%MiscMethods addrspace(1)* %10, float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00)
+  store float %12, float* %loc1
+  %13 = load float* %loc1
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %13, float 1.500000e+01)
+  %15 = zext i8 %14 to i32
+  %16 = icmp ne i32 %15, 0
+  br i1 %16, label %18, label %17
+
+; <label>:17                                      ; preds = %11
+  store i32 -1, i32* %loc0
+  br label %18
+
+; <label>:18                                      ; preds = %11, %17
+  %19 = load i32* %loc0
+  ret i32 %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method MiscMethods::Sum using LLILCJit
 Failed to read MiscMethods.Sum[loadElem]
 INFO:  jitting method BringUpTest::floatEqual using LLILCJit
@@ -2656,7 +3603,72 @@ entry:
 }
 
 INFO:  jitting method BringUpTest::InstanceCalls using LLILCJit
-Failed to read BringUpTest.InstanceCalls[Call needs null check]
+Successfully read BringUpTest.InstanceCalls
+
+define i32 @BringUpTest.InstanceCalls(%MiscMethods addrspace(1)* %param0, %"System.Double[]" addrspace(1)* %param1, double %param2, double %param3, double %param4, double %param5, double %param6) {
+entry:
+  %arg0 = alloca %MiscMethods addrspace(1)*
+  %arg1 = alloca %"System.Double[]" addrspace(1)*
+  %arg2 = alloca double
+  %arg3 = alloca double
+  %arg4 = alloca double
+  %arg5 = alloca double
+  %arg6 = alloca double
+  %loc0 = alloca i32
+  %loc1 = alloca double
+  %loc2 = alloca double
+  store %MiscMethods addrspace(1)* %param0, %MiscMethods addrspace(1)** %arg0
+  store %"System.Double[]" addrspace(1)* %param1, %"System.Double[]" addrspace(1)** %arg1
+  store double %param2, double* %arg2
+  store double %param3, double* %arg3
+  store double %param4, double* %arg4
+  store double %param5, double* %arg5
+  store double %param6, double* %arg6
+  store i32 100, i32* %loc0
+  %0 = load %MiscMethods addrspace(1)** %arg0
+  %1 = load %"System.Double[]" addrspace(1)** %arg1
+  %NullCheck = icmp ne %MiscMethods addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (%MiscMethods addrspace(1)*, %"System.Double[]" addrspace(1)*)*)(%MiscMethods addrspace(1)* %0, %"System.Double[]" addrspace(1)* %1)
+  store double %3, double* %loc1
+  %4 = load %MiscMethods addrspace(1)** %arg0
+  %5 = load double* %arg2
+  %6 = load double* %arg3
+  %7 = load double* %arg4
+  %8 = load double* %arg5
+  %9 = load double* %arg6
+  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %4, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %2
+  %11 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (%MiscMethods addrspace(1)*, double, double, double, double, double)*)(%MiscMethods addrspace(1)* %4, double %5, double %6, double %7, double %8, double %9)
+  store double %11, double* %loc2
+  %12 = load double* %loc1
+  %13 = load double* %loc2
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %12, double %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp ne i32 %15, 0
+  br i1 %16, label %18, label %17
+
+; <label>:17                                      ; preds = %10
+  store i32 -1, i32* %loc0
+  br label %18
+
+; <label>:18                                      ; preds = %10, %17
+  %19 = load i32* %loc0
+  ret i32 %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method MiscMethods::Sum using LLILCJit
 Failed to read MiscMethods.Sum[loadElem]
 INFO:  jitting method MiscMethods::Sum using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3419,31 +4252,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3516,7 +4368,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4285,6 +5171,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4420,6 +5326,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3488,31 +4321,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3585,7 +4437,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4354,6 +5240,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4489,6 +5395,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -2546,7 +3379,44 @@ entry:
 }
 
 INFO:  jitting method BringUpTest::ObjAlloc using LLILCJit
-Failed to read BringUpTest.ObjAlloc[Call needs null check]
+Successfully read BringUpTest.ObjAlloc
+
+define %Point addrspace(1)* @BringUpTest.ObjAlloc() {
+entry:
+  %loc0 = alloca %Point addrspace(1)*
+  %loc1 = alloca %Point addrspace(1)*
+  %loc2 = alloca i32
+  %0 = call %Point addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %Point addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%Point addrspace(1)*, i32, i32)*)(%Point addrspace(1)* %0, i32 10, i32 20)
+  store %Point addrspace(1)* %0, %Point addrspace(1)** %loc0
+  %1 = call %Point addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %Point addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%Point addrspace(1)*, i32, i32)*)(%Point addrspace(1)* %1, i32 10, i32 20)
+  store %Point addrspace(1)* %1, %Point addrspace(1)** %loc1
+  %2 = load %Point addrspace(1)** %loc0
+  %3 = load %Point addrspace(1)** %loc1
+  %NullCheck = icmp ne %Point addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%Point addrspace(1)*, %Point addrspace(1)*)*)(%Point addrspace(1)* %2, %Point addrspace(1)* %3)
+  store i32 %5, i32* %loc2
+  %6 = load i32* %loc2
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
+  ret %Point addrspace(1)* null
+
+; <label>:9                                       ; preds = %4
+  %10 = call %Point addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %Point addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%Point addrspace(1)*, i32, i32)*)(%Point addrspace(1)* %10, i32 0, i32 0)
+  ret %Point addrspace(1)* %10
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Point::.ctor using LLILCJit
 Successfully read Point..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -3910,31 +4743,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4007,7 +4859,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4776,6 +5662,26 @@ INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4911,6 +5817,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
 Failed to read TextWriter.WriteLine[Tail call]
 INFO:  jitting method StreamWriter::Write using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
@@ -2544,7 +3377,7 @@ entry:
 INFO:  jitting method Int32::ToString using LLILCJit
 Failed to read Int32.ToString[Tail call]
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
-Failed to read NumberFormatInfo.get_CurrentInfo[Call needs null check]
+Failed to read NumberFormatInfo.get_CurrentInfo[convertHandle]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4045,31 +4878,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4142,7 +4994,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit
 Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -4204,6 +5090,26 @@ INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -4339,6 +5245,8 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 INFO:  jitting method BringUpTest::Swap using LLILCJit
 Successfully read BringUpTest.Swap
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method SwitchTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method child::Main using LLILCJit

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method Complex_Array_Test::Main using LLILCJit
@@ -3321,31 +4154,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3418,7 +4270,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -3564,6 +4450,26 @@ INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -3699,4 +4605,6 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -1,7 +1,229 @@
 INFO:  jitting method AppDomain::SetupDomain using LLILCJit
-Failed to read AppDomain.SetupDomain[Call needs null check]
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
-Failed to read AppDomain.SetupFusionStore[Call needs null check]
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -279,14 +501,27 @@ ThrowNullRef1:                                    ; preds = %13
   unreachable
 }
 
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[Call needs null check]
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
-Failed to read AppDomainSetup..ctor[Call needs null check]
+Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Call needs null check]
+Failed to read String.Compare[Tail call]
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -458,7 +693,7 @@ Failed to read List`1.EnsureCapacity[Tail call]
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
-Failed to read AppDomainSetup.SetCompatibilitySwitches[Call needs null check]
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
@@ -487,16 +722,6 @@ INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
-INFO:  jitting method Object::.ctor using LLILCJit
-Successfully read Object..ctor
-
-define void @Object..ctor(%System.Object addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
-  ret void
-}
-
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
@@ -580,7 +805,7 @@ entry:
 INFO:  jitting method CultureInfo::Init using LLILCJit
 Failed to read CultureInfo.Init[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Call needs null check]
+Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
 Failed to read CultureData.GetCultureData[Tail call]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
@@ -692,7 +917,72 @@ Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
 Failed to read StringBuilder.ToString[loadElemA]
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
-Failed to read CultureData.CreateCultureData[Call needs null check]
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
@@ -714,7 +1004,81 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
-Failed to read CultureInfo.get_Name[Call needs null check]
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
 INFO:  jitting method String::EqualsHelper using LLILCJit
 Successfully read String.EqualsHelper
 
@@ -1002,7 +1366,105 @@ entry:
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
 Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
-Failed to read CompareInfo..ctor[Call needs null check]
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1127,7 +1589,39 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
-Failed to read AppDomainSetup.GetConfigurationBytes[Call needs null check]
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method KeyCollection::.ctor using LLILCJit
 Successfully read KeyCollection..ctor
 
@@ -1188,7 +1682,7 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
-Failed to read AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
@@ -1347,9 +1841,143 @@ entry:
 }
 
 INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
-Failed to read Path.HasIllegalCharacters[Call needs null check]
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
 INFO:  jitting method PathHelper::Append using LLILCJit
-Failed to read PathHelper.Append[Call needs null check]
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
 Failed to read PathHelper.OrdinalStartsWith[Tail call]
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
@@ -1507,7 +2135,7 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Call needs null check]
+Failed to read String.Equals[Tail call]
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -1950,7 +2578,7 @@ Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Failed to read Buffer._Memmove[Tail call]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[Call needs null check]
+Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -2015,7 +2643,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
-Failed to read AppDomain.GetData[Call needs null check]
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
 INFO:  jitting method AppDomainSetup::Locate using LLILCJit
 Successfully read AppDomainSetup.Locate
 
@@ -2066,8 +2694,6 @@ entry:
 
 INFO:  jitting method String::Equals using LLILCJit
 Failed to read String.Equals[Tail call]
-INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
@@ -2154,7 +2780,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Call needs null check]
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2185,7 +2811,67 @@ Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
 INFO:  jitting method TextInfo::.ctor using LLILCJit
-Failed to read TextInfo..ctor[Call needs null check]
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
 Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -2261,11 +2947,114 @@ entry:
 }
 
 INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
-Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
 INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
-Failed to read AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Call needs null check]
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -2296,7 +3085,7 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Call needs null check]
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -2429,7 +3218,51 @@ entry:
 }
 
 INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
 Successfully read PolicyStatement.get_PermissionSet
 
@@ -2483,7 +3316,7 @@ entry:
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[Call needs null check]
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -2523,7 +3356,7 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[Call needs null check]
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method Simple_Array_Test::Main using LLILCJit
@@ -3321,31 +4154,50 @@ entry:
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
 Failed to read StreamWriter.set_AutoFlush[Tail call]
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
-Failed to read StreamWriter.CheckAsyncTaskInProgress[Call needs null check]
-INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
-INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
-INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
-Successfully read EmptyArray`1..cctor
+Successfully read StreamWriter.CheckAsyncTaskInProgress
 
-define void @"EmptyArray`1..cctor"() {
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
 entry:
-  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
-  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
-INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
-INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
-Failed to read UTF8Encoding.GetBytes[Call needs null check]
-INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -3418,7 +4270,41 @@ entry:
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
-Failed to read TextWriter.get_FormatProvider[Call needs null check]
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -3564,6 +4450,26 @@ INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Failed to read StreamWriter.Write[Tail call]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
 Successfully read WindowsConsoleStream.Write
 
@@ -3699,4 +4605,6 @@ entry:
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
 


### PR DESCRIPTION
This implements adding null check for this call utilizing the latest null check implementation.
Since this only applies to this argument, I moved the check inside the loop that builds arguments.
