### PR TITLE
Refresh CoreCLR Test Assets every time.

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -419,16 +419,18 @@ function Global:GetCLRTestAssets
 {
   $CoreCLRTestAssets = CoreCLRTestAssets
   $CoreCLRTestAssetsExists = Test-Path $CoreCLRTestAssets
+  pushd .
   if (!$CoreCLRTestAssetsExists) {
-    pushd .
     New-Item $CoreCLRTestAssets -itemtype Directory  | Out-Null
     cd $CoreCLRTestAssets
     git clone git://github.com/dotnet/coreclr.git
-    popd
   }
   else {
-    Write-Host("CoreCLR Test Assets already downloaded.")
+    Write-Host("Updating CoreCLR Test Assets to latest...")
+    cd $CoreCLRTestAssets\coreclr
+    git pull
   }
+  popd
 }
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
Refresh CoreCLR Test Assets every time the dev env starts. This is part of the effort to make single test work flow smooth. Previously when a new test case is added to CoreCLR side and its baseline is added to LLILC side, it does not refresh the CoreCLR Test Assets to latest if developer does not remove the old the CoreCLRTestAssets, thus caused unmatching CoreCLR and LLILC test assets. It would solve the problem to refresh the CoreCLR test assets every time.
