### PR TITLE
Defer Check for DiffTool to CheckDiff

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -101,10 +101,6 @@ function ValidatePreConditions
 
   IsOnPath -executable "grep.exe" -software "GnuWin32"
 
-  # Validate Diff Tool
-  
-  IsOnPath -executable "sgdm.exe" -software "DiffMerge"
-
   # Validate LLVM
 
   $LLVMSourceExists = Test-Path Env:\LLVMSOURCE
@@ -819,6 +815,13 @@ function Global:CheckDiff([bool]$Create = $false, [bool]$UseDiffTool = $True, [s
   $CoreCLRTestTargetBinaries = CoreCLRTestTargetBinaries -Arch $Arch -Build $Build
 
   Write-Host ("Checking diff...")
+
+  if ($UseDiffTool) {
+    # Validate Diff Tool
+  
+    IsOnPath -executable "sgdm.exe" -software "DiffMerge"
+  }
+
   $DiffExists = Test-Path $LLILCTestResult\Diff
   if ($Create) {
     if ($DiffExists) {


### PR DESCRIPTION
If we are not using the difftool to do any diffs, we should not be
required to have the diff tool on the path. Therefore, we should defer
checking if sgdm.exe is available to the CheckDiff function, and only
check for it if the user has specified that they want to use the diff
tool.

This addresses issue #206 
