### PR TITLE
Clear NuGet Cache and fix diff tool checking problem.

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -330,7 +330,7 @@ function SetVCVars
 #
 # -------------------------------------------------------------------------
 
-function IsOnPath([string]$executable, [string]$software)
+function Global:IsOnPath([string]$executable, [string]$software)
 {
   if (-Not (Get-Command $executable -ErrorAction SilentlyContinue)) {
     throw  "!!! $executable not on path. Check the installation of $software."
@@ -376,6 +376,20 @@ function Global:DownloadNuGet
 
 # -------------------------------------------------------------------------
 #
+# Clear NuGet Cache
+# 
+# -------------------------------------------------------------------------
+
+function Global:ClearNuGetCache
+{
+  $NuGetCacheExists = Test-Path $Env:LOCALAPPDATA\NuGet\Cache
+  if ($NuGetCacheExists) {
+    Remove-Item $Env:LOCALAPPDATA\NuGet\Cache\*
+  }
+}
+
+# -------------------------------------------------------------------------
+#
 # Perform a CoreCLR package Nuget.
 # 
 # -------------------------------------------------------------------------
@@ -396,6 +410,8 @@ function Global:NuGetCLR
 
   Write-OutPut("Downloading NuGet.exe...")
   DownloadNuGet
+  Write-OutPut("Clear NuGet Cache...")
+  ClearNuGetCache
   copy $LLILCSource\utils\NuGet.config $CoreCLRRuntime
   copy $LLILCSource\utils\packages.config $CoreCLRRuntime
   pushd .


### PR DESCRIPTION
NuGet uses a cache for downloaded package so that a later NuGet request does not have to download again and uses a previously downloaded package. However sometimes on some machine it caused some unpredicted behavior that led to different versions of CoreCLR/CoreFX packages. Finally the difference is reflected in LLVM IR diffs we are catching. To exclude any of the unpredictable factors, an operation is performed to clear NuGet cache in the beginning of a session. Also fix a bug due to delaying diff tool check to CheckDiff.
