### PR TITLE
Fix function types for optimized delegate ctors

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -436,6 +436,7 @@ public:
   bool isCallVirt() { return IsCallVirt; }
   bool needsNullCheck() { return NeedsNullCheck; }
   bool usesMethodDesc() { return UsesMethodDesc; }
+  bool isOptimizedDelegateCtor() { return IsOptimizedDelegateCtor; }
   bool isReadOnlyCall() { return IsReadonlyCall; }
 
   mdToken getLoadFtnToken() { return LoadFtnToken; }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3011,8 +3011,9 @@ IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
   }
 
   // We may need to fix the type on the TargetNode.
-  const bool FixFunctionType =
-      CallTargetInfo->isCallVirt() || CallTargetInfo->isCallI();
+  const bool FixFunctionType = CallTargetInfo->isCallVirt() ||
+                               CallTargetInfo->isCallI() ||
+                               CallTargetInfo->isOptimizedDelegateCtor();
   if (FixFunctionType) {
     CORINFO_CLASS_HANDLE ThisClass = nullptr;
     if (SigInfo->hasThis()) {


### PR DESCRIPTION
The code in genCall that patches up `this` pointer types on function calls
needs to run for optimized delegate constructors also, since otherwise the
instance pointer argument is typed with the specific delegate type and the
instance parameter type in the function type is MulticastDelegate*.

Fixes #217
