### PR TITLE
Allow ptr - ptr subtraction

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3343,6 +3343,8 @@ IRNode *GenIR::convert(Type *Ty, Value *Node, bool SourceIsSigned) {
     Result = LLVMBuilder->CreateIntCast(Node, Ty, SourceIsSigned);
   } else if (SourceTy->isFloatingPointTy() && Ty->isFloatingPointTy()) {
     Result = LLVMBuilder->CreateFPCast(Node, Ty);
+  } else if (SourceTy->isPointerTy() && Ty->isIntegerTy()) {
+    Result = LLVMBuilder->CreatePtrToInt(Node, Ty);
   } else {
     ASSERT(UNREACHED);
   }


### PR DESCRIPTION
The code that inserts casts in binaryOp will try to cast both sources to
integer type when it sees a ptr - ptr subtraction.  This change adds the
code to handle that case the helper method that it calls to insert the
cast.

Fixes #218
