### PR TITLE
Change CoreCLRTestAssets remote URL

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -435,7 +435,10 @@ function Global:GetCLRTestAssets
   if (!$CoreCLRTestAssetsExists) {
     New-Item $CoreCLRTestAssets -itemtype Directory  | Out-Null
     cd $CoreCLRTestAssets
-    git clone git://github.com/dotnet/coreclr.git
+    git clone https://github.com/dotnet/coreclr.git
+    # set push url to bogus value to avoid inadvertent pushes
+    cd $CoreCLRTestAssets\coreclr
+    git remote set-url --push origin do_not_push
   }
   else {
     Write-Host("Updating CoreCLR Test Assets to latest...")


### PR DESCRIPTION
Use https rather than git; https works more reliably.
Explicitly set push url to a bogus value to still make sure nothing gets pushed inadvertently.
