### PR TITLE
Fail if NuGet does not successfully download

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -370,6 +370,12 @@ function Global:DownloadNuGet
     pushd .
     cd $CoreCLRRuntime
     Invoke-WebRequest http://nuget.org/NuGet.exe -OutFile NuGet.exe
+    $NuGetExists = Test-Path $CoreCLRRuntime\Nuget.exe
+
+    if (!$NuGetExists) {
+      throw "!!! NuGet failed to successfully download."
+    }
+
     popd
   }
 }


### PR DESCRIPTION
If there is an error in downloading NuGet, we want to fail early so
that we do not try to NuGet the CLR tests when NuGet does not exit.
We want to notify the user clearly that NuGet failed to download.
