### PR TITLE
Enable two additional tests

### DIFF
--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
@@ -1,0 +1,5395 @@
+INFO:  jitting method AppDomain::SetupDomain using LLILCJit
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
+Successfully read AppDomainSetup.VerifyDir
+
+define %System.String addrspace(1)* @AppDomainSetup.VerifyDir(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %16, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = icmp ne i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %2
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
+  br label %16
+
+; <label>:8                                       ; preds = %2
+  %9 = load i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.AppDomainSetup addrspace(1)** %this
+  %14 = load %System.String addrspace(1)** %arg1
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
+  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
+  br label %16
+
+; <label>:16                                      ; preds = %entry, %7, %8, %12
+  %17 = load %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %17
+}
+
+INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
+Failed to read AppDomainSetup.SetupDefaults[storeElem]
+INFO:  jitting method String::LastIndexOfAny using LLILCJit
+Failed to read String.LastIndexOfAny[Tail call]
+INFO:  jitting method String::Substring using LLILCJit
+Failed to read String.Substring[Tail call]
+INFO:  jitting method String::InternalSubString using LLILCJit
+Successfully read String.InternalSubString
+
+define %System.String addrspace(1)* @String.InternalSubString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i16 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32* %arg2
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
+  store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
+  %2 = load %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String addrspace(1)* %2, i32 0, i32 2
+  %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
+  store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
+  %6 = load %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %3
+  %8 = getelementptr inbounds %System.String addrspace(1)* %6, i32 0, i32 2
+  %9 = bitcast [0 x i16] addrspace(1)* %8 to i16 addrspace(1)*
+  store i16 addrspace(1)* %9, i16 addrspace(1)** %loc2
+  %10 = load i16 addrspace(1)** %loc1
+  %11 = ptrtoint i16 addrspace(1)* %10 to i64
+  %12 = load i16 addrspace(1)** %loc2
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = load i32* %arg1
+  %15 = sext i32 %14 to i64
+  %16 = mul i64 %15, 2
+  %17 = add i64 %13, %16
+  %18 = load i32* %arg2
+  %19 = inttoptr i64 %11 to i16*
+  %20 = inttoptr i64 %17 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %19, i16* %20, i32 %18)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc2
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  %21 = load %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::wstrcpy using LLILCJit
+Failed to read String.wstrcpy[Tail call]
+INFO:  jitting method Buffer::Memmove using LLILCJit
+Failed to read Buffer.Memmove[Tail call]
+INFO:  jitting method String::Concat using LLILCJit
+Successfully read String.Concat
+
+define %System.String addrspace(1)* @String.Concat(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** %arg1
+  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %5)
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %4
+  %12 = load %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)** %arg1
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.String addrspace(1)** %arg0
+  ret %System.String addrspace(1)* %19
+
+; <label>:20                                      ; preds = %13
+  %21 = load %System.String addrspace(1)** %arg0
+  %22 = getelementptr inbounds %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32 addrspace(1)* %22
+  store i32 %23, i32* %loc0
+  %24 = load i32* %loc0
+  %25 = load %System.String addrspace(1)** %arg1
+  %26 = getelementptr inbounds %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32 addrspace(1)* %26
+  %28 = add i32 %24, %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
+  %30 = load %System.String addrspace(1)** %loc1
+  %31 = load %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %32 = load %System.String addrspace(1)** %loc1
+  %33 = load i32* %loc0
+  %34 = load %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
+  %35 = load %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %35
+}
+
+INFO:  jitting method String::IsNullOrEmpty using LLILCJit
+Successfully read String.IsNullOrEmpty
+
+define i8 @String.IsNullOrEmpty(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %9, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** %arg0
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = icmp eq i32 %5, 0
+  %7 = sext i1 %6 to i32
+  %8 = trunc i32 %7 to i8
+  ret i8 %8
+
+; <label>:9                                       ; preds = %entry
+  ret i8 1
+}
+
+INFO:  jitting method String::FillStringChecked using LLILCJit
+Successfully read String.FillStringChecked
+
+define void @String.FillStringChecked(%System.String addrspace(1)* %param0, i32 %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)** %arg2
+  %1 = getelementptr inbounds %System.String addrspace(1)* %0, i32 0, i32 1
+  %2 = load i32 addrspace(1)* %1
+  %3 = load %System.String addrspace(1)** %arg0
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = load i32* %arg1
+  %7 = sub i32 %5, %6
+  %8 = icmp sle i32 %2, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String addrspace(1)* %12, i32 0, i32 2
+  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
+  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
+  %16 = load %System.String addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String addrspace(1)* %16, i32 0, i32 2
+  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
+  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
+  %20 = load i16 addrspace(1)** %loc0
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = load i32* %arg1
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = add i64 %21, %24
+  %26 = load i16 addrspace(1)** %loc1
+  %27 = ptrtoint i16 addrspace(1)* %26 to i64
+  %28 = load %System.String addrspace(1)** %arg2
+  %29 = getelementptr inbounds %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32 addrspace(1)* %29
+  %31 = inttoptr i64 %25 to i16*
+  %32 = inttoptr i64 %27 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
+INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Failed to read AppDomainSetup..ctor[storeElem]
+INFO:  jitting method List`1::.cctor using LLILCJit
+Failed to read List`1..cctor[callRuntimeHandleHelper]
+INFO:  jitting method String::Compare using LLILCJit
+Failed to read String.Compare[Tail call]
+INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
+Successfully read String.CompareOrdinalIgnoreCaseHelper
+
+define i32 @String.CompareOrdinalIgnoreCaseHelper(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i16 addrspace(1)*
+  %loc3 = alloca i16*
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca i32
+  %loc7 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = getelementptr inbounds %System.String addrspace(1)* %0, i32 0, i32 1
+  %2 = load i32 addrspace(1)* %1
+  %3 = load %System.String addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
+  store i32 %6, i32* %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.String addrspace(1)* %7, i32 0, i32 2
+  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
+  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
+  %11 = load %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %System.String addrspace(1)* %11, i32 0, i32 2
+  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
+  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
+  %15 = load i16 addrspace(1)** %loc1
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc3
+  %18 = load i16 addrspace(1)** %loc2
+  %19 = ptrtoint i16 addrspace(1)* %18 to i64
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc4
+  br label %60
+
+; <label>:21                                      ; preds = %60
+  %22 = load i16** %loc3
+  %23 = load i16* %22, align 8
+  %24 = zext i16 %23 to i32
+  store i32 %24, i32* %loc5
+  %25 = load i16** %loc4
+  %26 = load i16* %25, align 8
+  %27 = zext i16 %26 to i32
+  store i32 %27, i32* %loc6
+  %28 = load i32* %loc5
+  %29 = sub i32 %28, 97
+  %30 = icmp ugt i32 %29, 25
+  br i1 %30, label %34, label %31
+
+; <label>:31                                      ; preds = %21
+  %32 = load i32* %loc5
+  %33 = sub i32 %32, 32
+  store i32 %33, i32* %loc5
+  br label %34
+
+; <label>:34                                      ; preds = %21, %31
+  %35 = load i32* %loc6
+  %36 = sub i32 %35, 97
+  %37 = icmp ugt i32 %36, 25
+  br i1 %37, label %41, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load i32* %loc6
+  %40 = sub i32 %39, 32
+  store i32 %40, i32* %loc6
+  br label %41
+
+; <label>:41                                      ; preds = %34, %38
+  %42 = load i32* %loc5
+  %43 = load i32* %loc6
+  %44 = icmp eq i32 %42, %43
+  br i1 %44, label %49, label %45
+
+; <label>:45                                      ; preds = %41
+  %46 = load i32* %loc5
+  %47 = load i32* %loc6
+  %48 = sub i32 %46, %47
+  store i32 %48, i32* %loc7
+  br label %71
+
+; <label>:49                                      ; preds = %41
+  %50 = load i16** %loc3
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8* %51, i64 2
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc3
+  %54 = load i16** %loc4
+  %55 = bitcast i16* %54 to i8*
+  %56 = getelementptr inbounds i8* %55, i64 2
+  %57 = bitcast i8* %56 to i16*
+  store i16* %57, i16** %loc4
+  %58 = load i32* %loc0
+  %59 = sub i32 %58, 1
+  store i32 %59, i32* %loc0
+  br label %60
+
+; <label>:60                                      ; preds = %12, %49
+  %61 = load i32* %loc0
+  %62 = icmp ne i32 %61, 0
+  br i1 %62, label %21, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.String addrspace(1)** %arg0
+  %65 = getelementptr inbounds %System.String addrspace(1)* %64, i32 0, i32 1
+  %66 = load i32 addrspace(1)* %65
+  %67 = load %System.String addrspace(1)** %arg1
+  %68 = getelementptr inbounds %System.String addrspace(1)* %67, i32 0, i32 1
+  %69 = load i32 addrspace(1)* %68
+  %70 = sub i32 %66, %69
+  store i32 %70, i32* %loc7
+  br label %71
+
+; <label>:71                                      ; preds = %45, %63
+  %72 = load i32* %loc7
+  ret i32 %72
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Math::Min using LLILCJit
+Successfully read Math.Min
+
+define i32 @Math.Min(i32 %param0, i32 %param1) {
+entry:
+  %arg0 = alloca i32
+  %arg1 = alloca i32
+  store i32 %param0, i32* %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg0
+  %1 = load i32* %arg1
+  %2 = icmp sle i32 %0, %1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i32* %arg1
+  ret i32 %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32* %arg0
+  ret i32 %6
+}
+
+INFO:  jitting method List`1::Add using LLILCJit
+Failed to read List`1.Add[storeElem]
+INFO:  jitting method List`1::EnsureCapacity using LLILCJit
+Failed to read List`1.EnsureCapacity[Tail call]
+INFO:  jitting method List`1::set_Capacity using LLILCJit
+Failed to read List`1.set_Capacity[non-const derefAddress]
+INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
+INFO:  jitting method Dictionary`2::.ctor using LLILCJit
+Failed to read Dictionary`2..ctor[Call HasTypeArg]
+INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
+Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
+INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
+Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
+INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
+Failed to read RuntimeType.IsAssignableFrom[Tail call]
+INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
+Successfully read RuntimeType.get_UnderlyingSystemType
+
+define %System.Type addrspace(1)* @RuntimeType.get_UnderlyingSystemType(%System.RuntimeType addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  %0 = load %System.RuntimeType addrspace(1)** %this
+  %1 = bitcast %System.RuntimeType addrspace(1)* %0 to %System.Type addrspace(1)*
+  ret %System.Type addrspace(1)* %1
+}
+
+INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
+Failed to read GenericEqualityComparer`1..ctor[Tail call]
+INFO:  jitting method HashHelpers::.cctor using LLILCJit
+Failed to read HashHelpers..cctor[convertHandle]
+INFO:  jitting method String::UseRandomizedHashing using LLILCJit
+Failed to read String.UseRandomizedHashing[Tail call]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
+Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
+INFO:  jitting method Enumerator::MoveNext using LLILCJit
+Failed to read Enumerator.MoveNext[loadElem]
+INFO:  jitting method Enumerator::get_Current using LLILCJit
+Successfully read Enumerator.get_Current
+
+define %System.__Canon addrspace(1)* @Enumerator.get_Current(%"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.__Canon addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::.cctor using LLILCJit
+Successfully read StringComparer..cctor
+
+define void @StringComparer..cctor() {
+entry:
+  %0 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %1 = call %System.CultureAwareComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.CultureAwareComparer addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.CultureAwareComparer addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*, i8)*)(%System.CultureAwareComparer addrspace(1)* %1, %System.Globalization.CultureInfo addrspace(1)* %0, i8 0)
+  %2 = bitcast %System.CultureAwareComparer addrspace(1)* %1 to %System.StringComparer addrspace(1)*
+  %3 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %4 = getelementptr inbounds i8 addrspace(1)* %3, i64 56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.StringComparer addrspace(1)*)*)(i8 addrspace(1)* %4, %System.StringComparer addrspace(1)* %2)
+  %5 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %6 = call %System.CultureAwareComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.CultureAwareComparer addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.CultureAwareComparer addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*, i8)*)(%System.CultureAwareComparer addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)* %5, i8 1)
+  %7 = bitcast %System.CultureAwareComparer addrspace(1)* %6 to %System.StringComparer addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.StringComparer addrspace(1)*)*)(i8 addrspace(1)* %9, %System.StringComparer addrspace(1)* %7)
+  %10 = call %System.OrdinalComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OrdinalComparer addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OrdinalComparer addrspace(1)*, i8)*)(%System.OrdinalComparer addrspace(1)* %10, i8 0)
+  %11 = bitcast %System.OrdinalComparer addrspace(1)* %10 to %System.StringComparer addrspace(1)*
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.StringComparer addrspace(1)*)*)(i8 addrspace(1)* %13, %System.StringComparer addrspace(1)* %11)
+  %14 = call %System.OrdinalComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OrdinalComparer addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OrdinalComparer addrspace(1)*, i8)*)(%System.OrdinalComparer addrspace(1)* %14, i8 1)
+  %15 = bitcast %System.OrdinalComparer addrspace(1)* %14 to %System.StringComparer addrspace(1)*
+  %16 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %17 = getelementptr inbounds i8 addrspace(1)* %16, i64 80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.StringComparer addrspace(1)*)*)(i8 addrspace(1)* %17, %System.StringComparer addrspace(1)* %15)
+  ret void
+}
+
+INFO:  jitting method CultureInfo::get_InvariantCulture using LLILCJit
+Successfully read CultureInfo.get_InvariantCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_InvariantCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
+INFO:  jitting method CultureInfo::.cctor using LLILCJit
+Successfully read CultureInfo..cctor
+
+define void @CultureInfo..cctor() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  %3 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %4 = getelementptr inbounds i8 addrspace(1)* %3, i64 2201
+  %5 = addrspacecast i8 addrspace(1)* %4 to i8*
+  store i8 %2, i8* %5
+  ret void
+}
+
+INFO:  jitting method CultureInfo::Init using LLILCJit
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
+INFO:  jitting method CultureInfo::.ctor using LLILCJit
+Failed to read CultureInfo..ctor[Call intrinsic]
+INFO:  jitting method CultureData::GetCultureData using LLILCJit
+Failed to read CultureData.GetCultureData[Tail call]
+INFO:  jitting method CultureData::get_Invariant using LLILCJit
+Failed to read CultureData.get_Invariant[storeElem]
+INFO:  jitting method CalendarData::.cctor using LLILCJit
+Failed to read CalendarData..cctor[storeElem]
+INFO:  jitting method CalendarData::.ctor using LLILCJit
+Failed to read CalendarData..ctor[init class]
+INFO:  jitting method CultureData::get_CultureName using LLILCJit
+Successfully read CultureData.get_CultureName
+
+define %System.String addrspace(1)* @CultureData.get_CultureName(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
+  %3 = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** %loc0
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %16, label %10
+
+; <label>:10                                      ; preds = %4
+  %11 = load %System.String addrspace(1)** %loc0
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %4, %10
+  %17 = load %System.Globalization.CultureData addrspace(1)** %this
+  %18 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
+  %19 = load %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+; <label>:20                                      ; preds = %entry, %10
+  %21 = load %System.Globalization.CultureData addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+}
+
+INFO:  jitting method String::op_Equality using LLILCJit
+Failed to read String.op_Equality[Tail call]
+INFO:  jitting method String::Equals using LLILCJit
+Failed to read String.Equals[Tail call]
+INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
+Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
+Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
+INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
+Successfully read CultureInfo.GetCultureByName
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.GetCultureByName(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %6, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  br label %9
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %5, %3 ], [ %8, %6 ]
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  br label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+}
+
+INFO:  jitting method CultureInfo::.ctor using LLILCJit
+Failed to read CultureInfo..ctor[Tail call]
+INFO:  jitting method CultureData::AnsiToLower using LLILCJit
+Failed to read CultureData.AnsiToLower[Tail call]
+INFO:  jitting method StringBuilder::.ctor using LLILCJit
+Failed to read StringBuilder..ctor[storeElem]
+INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
+Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+INFO:  jitting method StringBuilder::Append using LLILCJit
+Failed to read StringBuilder.Append[storeElem]
+INFO:  jitting method StringBuilder::ToString using LLILCJit
+Failed to read StringBuilder.ToString[loadElemA]
+INFO:  jitting method CultureData::CreateCultureData using LLILCJit
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
+INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
+Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
+INFO:  jitting method Dictionary`2::Insert using LLILCJit
+Failed to read Dictionary`2.Insert[non-const derefAddress]
+INFO:  jitting method Dictionary`2::Initialize using LLILCJit
+Failed to read Dictionary`2.Initialize[non-const derefAddress]
+INFO:  jitting method HashHelpers::GetPrime using LLILCJit
+Failed to read HashHelpers.GetPrime[loadElem]
+INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
+Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+INFO:  jitting method String::GetHashCode using LLILCJit
+Failed to read String.GetHashCode[Tail call]
+INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
+Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
+Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
+INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
+INFO:  jitting method CultureInfo::get_Name using LLILCJit
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
+INFO:  jitting method String::EqualsHelper using LLILCJit
+Successfully read String.EqualsHelper
+
+define i8 @String.EqualsHelper(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i16 addrspace(1)*
+  %loc3 = alloca i16*
+  %loc4 = alloca i16*
+  %loc5 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = getelementptr inbounds %System.String addrspace(1)* %0, i32 0, i32 1
+  %2 = load i32 addrspace(1)* %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 2
+  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
+  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
+  %7 = load %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.String addrspace(1)* %7, i32 0, i32 2
+  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
+  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
+  %11 = load i16 addrspace(1)** %loc1
+  %12 = ptrtoint i16 addrspace(1)* %11 to i64
+  %13 = inttoptr i64 %12 to i16*
+  store i16* %13, i16** %loc3
+  %14 = load i16 addrspace(1)** %loc2
+  %15 = ptrtoint i16 addrspace(1)* %14 to i64
+  %16 = inttoptr i64 %15 to i16*
+  store i16* %16, i16** %loc4
+  br label %63
+
+; <label>:17                                      ; preds = %63
+  %18 = load i16** %loc3
+  %19 = bitcast i16* %18 to i64*
+  %20 = load i64* %19, align 8
+  %21 = load i16** %loc4
+  %22 = bitcast i16* %21 to i64*
+  %23 = load i64* %22, align 8
+  %24 = icmp eq i64 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  store i8 0, i8* %loc5
+  br label %96
+
+; <label>:26                                      ; preds = %17
+  %27 = load i16** %loc3
+  %28 = bitcast i16* %27 to i8*
+  %29 = getelementptr inbounds i8* %28, i64 8
+  %30 = bitcast i8* %29 to i64*
+  %31 = load i64* %30, align 8
+  %32 = load i16** %loc4
+  %33 = bitcast i16* %32 to i8*
+  %34 = getelementptr inbounds i8* %33, i64 8
+  %35 = bitcast i8* %34 to i64*
+  %36 = load i64* %35, align 8
+  %37 = icmp eq i64 %31, %36
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %26
+  store i8 0, i8* %loc5
+  br label %96
+
+; <label>:39                                      ; preds = %26
+  %40 = load i16** %loc3
+  %41 = bitcast i16* %40 to i8*
+  %42 = getelementptr inbounds i8* %41, i64 16
+  %43 = bitcast i8* %42 to i64*
+  %44 = load i64* %43, align 8
+  %45 = load i16** %loc4
+  %46 = bitcast i16* %45 to i8*
+  %47 = getelementptr inbounds i8* %46, i64 16
+  %48 = bitcast i8* %47 to i64*
+  %49 = load i64* %48, align 8
+  %50 = icmp eq i64 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %39
+  store i8 0, i8* %loc5
+  br label %96
+
+; <label>:52                                      ; preds = %39
+  %53 = load i16** %loc3
+  %54 = bitcast i16* %53 to i8*
+  %55 = getelementptr inbounds i8* %54, i64 24
+  %56 = bitcast i8* %55 to i16*
+  store i16* %56, i16** %loc3
+  %57 = load i16** %loc4
+  %58 = bitcast i16* %57 to i8*
+  %59 = getelementptr inbounds i8* %58, i64 24
+  %60 = bitcast i8* %59 to i16*
+  store i16* %60, i16** %loc4
+  %61 = load i32* %loc0
+  %62 = sub i32 %61, 12
+  store i32 %62, i32* %loc0
+  br label %63
+
+; <label>:63                                      ; preds = %8, %52
+  %64 = load i32* %loc0
+  %65 = icmp sge i32 %64, 12
+  br i1 %65, label %17, label %66
+
+; <label>:66                                      ; preds = %63
+  br label %86
+
+; <label>:67                                      ; preds = %86
+  %68 = load i16** %loc3
+  %69 = bitcast i16* %68 to i32*
+  %70 = load i32* %69, align 8
+  %71 = load i16** %loc4
+  %72 = bitcast i16* %71 to i32*
+  %73 = load i32* %72, align 8
+  %74 = icmp ne i32 %70, %73
+  br i1 %74, label %89, label %75
+
+; <label>:75                                      ; preds = %67
+  %76 = load i16** %loc3
+  %77 = bitcast i16* %76 to i8*
+  %78 = getelementptr inbounds i8* %77, i64 4
+  %79 = bitcast i8* %78 to i16*
+  store i16* %79, i16** %loc3
+  %80 = load i16** %loc4
+  %81 = bitcast i16* %80 to i8*
+  %82 = getelementptr inbounds i8* %81, i64 4
+  %83 = bitcast i8* %82 to i16*
+  store i16* %83, i16** %loc4
+  %84 = load i32* %loc0
+  %85 = sub i32 %84, 2
+  store i32 %85, i32* %loc0
+  br label %86
+
+; <label>:86                                      ; preds = %66, %75
+  %87 = load i32* %loc0
+  %88 = icmp sgt i32 %87, 0
+  br i1 %88, label %67, label %89
+
+; <label>:89                                      ; preds = %67, %86
+  %90 = load i32* %loc0
+  %91 = icmp sgt i32 %90, 0
+  %92 = sext i1 %91 to i32
+  %93 = icmp eq i32 %92, 0
+  %94 = sext i1 %93 to i32
+  %95 = trunc i32 %94 to i8
+  store i8 %95, i8* %loc5
+  br label %96
+
+; <label>:96                                      ; preds = %25, %38, %51, %89
+  %97 = load i8* %loc5
+  %98 = zext i8 %97 to i32
+  %99 = trunc i32 %98 to i8
+  ret i8 %99
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureAwareComparer::.ctor using LLILCJit
+Successfully read CultureAwareComparer..ctor
+
+define void @CultureAwareComparer..ctor(%System.CultureAwareComparer addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.CultureAwareComparer addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg2 = alloca i8
+  store %System.CultureAwareComparer addrspace(1)* %param0, %System.CultureAwareComparer addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.CultureAwareComparer addrspace(1)** %this
+  %1 = bitcast %System.CultureAwareComparer addrspace(1)* %0 to %System.StringComparer addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
+  %2 = load %System.CultureAwareComparer addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
+  %5 = load i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %14 = getelementptr inbounds %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
+  %15 = load %System.CultureAwareComparer addrspace(1)** %this
+  %16 = load i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
+  store i8 %18, i8 addrspace(1)* %19
+  ret void
+}
+
+INFO:  jitting method StringComparer::.ctor using LLILCJit
+Failed to read StringComparer..ctor[Tail call]
+INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
+Successfully read CultureInfo.get_CompareInfo
+
+define %System.Globalization.CompareInfo addrspace(1)* @CultureInfo.get_CompareInfo(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %2 = load %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %3, label %38, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
+  %7 = zext i8 %6 to i32
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %12, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
+  br label %27
+
+; <label>:12                                      ; preds = %4
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64 addrspace(1)* %17
+  %19 = add i64 %18, 72
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64* %20
+  %22 = add i64 %21, 16
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64* %23
+  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
+  br label %27
+
+; <label>:27                                      ; preds = %9, %12
+  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %30 = zext i8 %29 to i32
+  %31 = icmp eq i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %27
+  %33 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %34 = load %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %35 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
+  br label %38
+
+; <label>:36                                      ; preds = %27
+  %37 = load %System.Globalization.CompareInfo addrspace(1)** %loc0
+  ret %System.Globalization.CompareInfo addrspace(1)* %37
+
+; <label>:38                                      ; preds = %entry, %32
+  %39 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %40 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
+  %41 = load %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %41
+}
+
+INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
+Failed to read CultureInfo.get_UseUserOverride[Tail call]
+INFO:  jitting method CompareInfo::.ctor using LLILCJit
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
+Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
+
+define i8 @CompatibilitySwitches.get_IsCompatibilityBehaviorDefined() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1986
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
+INFO:  jitting method OrdinalComparer::.ctor using LLILCJit
+Successfully read OrdinalComparer..ctor
+
+define void @OrdinalComparer..ctor(%System.OrdinalComparer addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca i8
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.OrdinalComparer addrspace(1)** %this
+  %1 = bitcast %System.OrdinalComparer addrspace(1)* %0 to %System.StringComparer addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
+  %2 = load %System.OrdinalComparer addrspace(1)** %this
+  %3 = load i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %6
+  ret void
+}
+
+INFO:  jitting method OrdinalComparer::Equals using LLILCJit
+Failed to read OrdinalComparer.Equals[Tail call]
+INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
+Successfully read Enumerator.MoveNextRare
+
+define i8 @Enumerator.MoveNextRare(%"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
+  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
+  %7 = load i32 addrspace(1)* %6, align 8
+  %8 = icmp eq i32 %2, %7
+  br i1 %8, label %10, label %9
+
+; <label>:9                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %9
+  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
+  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
+  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
+  %16 = load i32 addrspace(1)* %15, align 8
+  %17 = add i32 %16, 1
+  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
+  store i32 %17, i32 addrspace(1)* %18
+  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
+
+; <label>:20                                      ; preds = %10
+  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Enumerator::Dispose using LLILCJit
+Successfully read Enumerator.Dispose
+
+define void @Enumerator.Dispose(%"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  ret void
+}
+
+INFO:  jitting method AppDomain::Setup using LLILCJit
+Failed to read AppDomain.Setup[loadElem]
+INFO:  jitting method Thread::GetDomain using LLILCJit
+Successfully read Thread.GetDomain
+
+define %System.AppDomain addrspace(1)* @Thread.GetDomain() {
+entry:
+  %loc0 = alloca %System.AppDomain addrspace(1)*
+  %0 = call %System.AppDomain addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomain addrspace(1)* ()*)()
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc0
+  %1 = load %System.AppDomain addrspace(1)** %loc0
+  %2 = icmp ne %System.AppDomain addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.AppDomain addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomain addrspace(1)* ()*)()
+  store %System.AppDomain addrspace(1)* %4, %System.AppDomain addrspace(1)** %loc0
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %3
+  %6 = load %System.AppDomain addrspace(1)** %loc0
+  ret %System.AppDomain addrspace(1)* %6
+}
+
+INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method KeyCollection::.ctor using LLILCJit
+Successfully read KeyCollection..ctor
+
+define void @KeyCollection..ctor(%"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param1, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
+  %3 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 1)
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
+  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  ret void
+}
+
+INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
+Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
+INFO:  jitting method Enumerator::MoveNext using LLILCJit
+Failed to read Enumerator.MoveNext[loadElemA]
+INFO:  jitting method Enumerator::get_Current using LLILCJit
+Successfully read Enumerator.get_Current
+
+define %System.__Canon addrspace(1)* @Enumerator.get_Current(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.__Canon addrspace(1)* %2
+}
+
+INFO:  jitting method Enumerator::Dispose using LLILCJit
+Successfully read Enumerator.Dispose
+
+define void @Enumerator.Dispose(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
+INFO:  jitting method Path::.cctor using LLILCJit
+Failed to read Path..cctor[convertHandle]
+INFO:  jitting method String::SplitInternal using LLILCJit
+Failed to read String.SplitInternal[Tail call]
+INFO:  jitting method String::MakeSeparatorList using LLILCJit
+Failed to read String.MakeSeparatorList[loadElemA]
+INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
+Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+INFO:  jitting method Path::IsRelative using LLILCJit
+Successfully read Path.IsRelative
+
+define i8 @Path.IsRelative(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = getelementptr inbounds %System.String addrspace(1)* %0, i32 0, i32 1
+  %2 = load i32 addrspace(1)* %1
+  %3 = icmp slt i32 %2, 3
+  br i1 %3, label %50, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** %arg0
+  %6 = getelementptr inbounds %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
+  %7 = load i16 addrspace(1)* %6
+  %8 = zext i16 %7 to i32
+  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %10 = getelementptr inbounds i8 addrspace(1)* %9, i64 2380
+  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
+  %12 = load i16* %11
+  %13 = zext i16 %12 to i32
+  %14 = icmp ne i32 %8, %13
+  br i1 %14, label %50, label %15
+
+; <label>:15                                      ; preds = %4
+  %16 = load %System.String addrspace(1)** %arg0
+  %17 = getelementptr inbounds %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
+  %18 = load i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 2376
+  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
+  %23 = load i16* %22
+  %24 = zext i16 %23 to i32
+  %25 = icmp ne i32 %19, %24
+  br i1 %25, label %50, label %26
+
+; <label>:26                                      ; preds = %15
+  %27 = load %System.String addrspace(1)** %arg0
+  %28 = getelementptr inbounds %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
+  %29 = load i16 addrspace(1)* %28
+  %30 = zext i16 %29 to i32
+  %31 = icmp slt i32 %30, 97
+  br i1 %31, label %38, label %32
+
+; <label>:32                                      ; preds = %26
+  %33 = load %System.String addrspace(1)** %arg0
+  %34 = getelementptr inbounds %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
+  %35 = load i16 addrspace(1)* %34
+  %36 = zext i16 %35 to i32
+  %37 = icmp sle i32 %36, 122
+  br i1 %37, label %67, label %38
+
+; <label>:38                                      ; preds = %26, %32
+  %39 = load %System.String addrspace(1)** %arg0
+  %40 = getelementptr inbounds %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
+  %41 = load i16 addrspace(1)* %40
+  %42 = zext i16 %41 to i32
+  %43 = icmp slt i32 %42, 65
+  br i1 %43, label %50, label %44
+
+; <label>:44                                      ; preds = %38
+  %45 = load %System.String addrspace(1)** %arg0
+  %46 = getelementptr inbounds %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+  %47 = load i16 addrspace(1)* %46
+  %48 = zext i16 %47 to i32
+  %49 = icmp sle i32 %48, 90
+  br i1 %49, label %67, label %50
+
+; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+  %51 = load %System.String addrspace(1)** %arg0
+  %52 = getelementptr inbounds %System.String addrspace(1)* %51, i32 0, i32 1
+  %53 = load i32 addrspace(1)* %52
+  %54 = icmp slt i32 %53, 2
+  br i1 %54, label %68, label %55
+
+; <label>:55                                      ; preds = %50
+  %56 = load %System.String addrspace(1)** %arg0
+  %57 = getelementptr inbounds %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
+  %58 = load i16 addrspace(1)* %57
+  %59 = zext i16 %58 to i32
+  %60 = icmp ne i32 %59, 92
+  br i1 %60, label %68, label %61
+
+; <label>:61                                      ; preds = %55
+  %62 = load %System.String addrspace(1)** %arg0
+  %63 = getelementptr inbounds %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
+  %64 = load i16 addrspace(1)* %63
+  %65 = zext i16 %64 to i32
+  %66 = icmp ne i32 %65, 92
+  br i1 %66, label %68, label %67
+
+; <label>:67                                      ; preds = %32, %44, %61
+  ret i8 0
+
+; <label>:68                                      ; preds = %50, %55, %61
+  ret i8 1
+}
+
+INFO:  jitting method Path::NormalizePath using LLILCJit
+Failed to read Path.NormalizePath[entryLabel]
+INFO:  jitting method String::TrimHelper using LLILCJit
+Failed to read String.TrimHelper[loadElem]
+INFO:  jitting method String::CreateTrimmedString using LLILCJit
+Failed to read String.CreateTrimmedString[Tail call]
+INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
+Successfully read Path.CheckInvalidPathChars
+
+define void @Path.CheckInvalidPathChars(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** %arg0
+  %7 = load i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = trunc i32 %8 to i8
+  %10 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %6, i8 %9)
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %5
+  ret void
+}
+
+INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
+INFO:  jitting method PathHelper::Append using LLILCJit
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
+INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
+Failed to read PathHelper.OrdinalStartsWith[Tail call]
+INFO:  jitting method PathHelper::NullTerminate using LLILCJit
+Successfully read PathHelper.NullTerminate
+
+define void @PathHelper.NullTerminate(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %2 = load i16* addrspace(1)* %1, align 8
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = sext i32 %5 to i64
+  %7 = mul i64 %6, 2
+  %8 = bitcast i16* %2 to i8*
+  %9 = getelementptr inbounds i8* %8, i64 %7
+  %10 = bitcast i8* %9 to i32*
+  store i32 0, i32* %10, align 8
+  ret void
+}
+
+INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
+Failed to read PathHelper.GetFullPathName[entryLabel]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method PathHelper::ToString using LLILCJit
+Failed to read PathHelper.ToString[Tail call]
+INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
+Successfully read String.CtorCharPtrStartLength
+
+define %System.String addrspace(1)* @String.CtorCharPtrStartLength(%System.String addrspace(1)* %param0, i16* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16*
+  %loc1 = alloca %System.String addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %System.String addrspace(1)*
+  %loc4 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32* %arg3
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i16** %arg1
+  %17 = load i32* %arg2
+  %18 = sext i32 %17 to i64
+  %19 = mul i64 %18, 2
+  %20 = bitcast i16* %16 to i8*
+  %21 = getelementptr inbounds i8* %20, i64 %19
+  %22 = bitcast i8* %21 to i16*
+  store i16* %22, i16** %loc0
+  %23 = load i16** %loc0
+  %24 = load i16** %arg1
+  %25 = icmp uge i16* %23, %24
+  br i1 %25, label %31, label %26
+
+; <label>:26                                      ; preds = %15
+  %27 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %28 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %28)
+  %30 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %30, %System.String addrspace(1)* %27, %System.String addrspace(1)* %29)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %30) #0
+  unreachable
+
+; <label>:31                                      ; preds = %15
+  %32 = load i32* %arg3
+  %33 = icmp ne i32 %32, 0
+  br i1 %33, label %36, label %34
+
+; <label>:34                                      ; preds = %31
+  %35 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %35
+
+; <label>:36                                      ; preds = %31
+  %37 = load i32* %arg3
+  %38 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %37)
+  store %System.String addrspace(1)* %38, %System.String addrspace(1)** %loc1
+  %39 = load %System.String addrspace(1)** %loc1
+  store %System.String addrspace(1)* %39, %System.String addrspace(1)** %loc4
+  %40 = load %System.String addrspace(1)** %loc4
+  %41 = ptrtoint %System.String addrspace(1)* %40 to i64
+  %42 = icmp eq i64 %41, 0
+  br i1 %42, label %47, label %43
+
+; <label>:43                                      ; preds = %36
+  %44 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %45 = sext i32 %44 to i64
+  %46 = add i64 %41, %45
+  br label %47
+
+; <label>:47                                      ; preds = %36, %43
+  %48 = phi i64 [ %41, %36 ], [ %46, %43 ]
+  %49 = inttoptr i64 %48 to i16*
+  store i16* %49, i16** %loc2
+  %50 = load i16** %loc2
+  %51 = load i16** %loc0
+  %52 = load i32* %arg3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %50, i16* %51, i32 %52)
+  br label %53
+
+; <label>:53                                      ; preds = %47
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc4
+  br label %54
+
+; <label>:54                                      ; preds = %53
+  %55 = load %System.String addrspace(1)** %loc1
+  store %System.String addrspace(1)* %55, %System.String addrspace(1)** %loc3
+  br label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = load %System.String addrspace(1)** %loc3
+  ret %System.String addrspace(1)* %57
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
+INFO:  jitting method String::Equals using LLILCJit
+Failed to read String.Equals[Tail call]
+INFO:  jitting method StringBuilder::Append using LLILCJit
+Failed to read StringBuilder.Append[storeElem]
+INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
+Successfully read StringBuilder.AppendHelper
+
+define void @StringBuilder.AppendHelper(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca %System.String addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc1
+  %1 = load %System.String addrspace(1)** %loc1
+  %2 = ptrtoint %System.String addrspace(1)* %1 to i64
+  %3 = icmp eq i64 %2, 0
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %6 = sext i32 %5 to i64
+  %7 = add i64 %2, %6
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = phi i64 [ %2, %entry ], [ %7, %4 ]
+  %10 = inttoptr i64 %9 to i16*
+  store i16* %10, i16** %loc0
+  %11 = load %System.Text.StringBuilder addrspace(1)** %this
+  %12 = load i16** %loc0
+  %13 = load %System.String addrspace(1)** %arg1
+  %14 = getelementptr inbounds %System.String addrspace(1)* %13, i32 0, i32 1
+  %15 = load i32 addrspace(1)* %14
+  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
+  ret void
+}
+
+INFO:  jitting method StringBuilder::Append using LLILCJit
+Successfully read StringBuilder.Append
+
+define %System.Text.StringBuilder addrspace(1)* @StringBuilder.Append(%System.Text.StringBuilder addrspace(1)* %param0, i16* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32* %arg2
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg2
+  %9 = load %System.Text.StringBuilder addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %11 = load i32 addrspace(1)* %10, align 8
+  %12 = add i32 %8, %11
+  store i32 %12, i32* %loc0
+  %13 = load i32* %loc0
+  %14 = load %System.Text.StringBuilder addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
+  %16 = load %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = getelementptr inbounds %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
+  %18 = load i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %13, %20
+  br i1 %21, label %34, label %22
+
+; <label>:22                                      ; preds = %7
+  %23 = load i16** %arg1
+  %24 = load %System.Text.StringBuilder addrspace(1)** %this
+  %25 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
+  %26 = load %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+  %27 = load %System.Text.StringBuilder addrspace(1)** %this
+  %28 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
+  %29 = load i32 addrspace(1)* %28, align 8
+  %30 = load i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %31 = load %System.Text.StringBuilder addrspace(1)** %this
+  %32 = load i32* %loc0
+  %33 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
+  store i32 %32, i32 addrspace(1)* %33
+  br label %86
+
+; <label>:34                                      ; preds = %7
+  %35 = load %System.Text.StringBuilder addrspace(1)** %this
+  %36 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
+  %37 = load %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
+  %38 = getelementptr inbounds %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %39 = load i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load %System.Text.StringBuilder addrspace(1)** %this
+  %43 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
+  %44 = load i32 addrspace(1)* %43, align 8
+  %45 = sub i32 %41, %44
+  store i32 %45, i32* %loc1
+  %46 = load i32* %loc1
+  %47 = icmp sle i32 %46, 0
+  br i1 %47, label %66, label %48
+
+; <label>:48                                      ; preds = %34
+  %49 = load i16** %arg1
+  %50 = load %System.Text.StringBuilder addrspace(1)** %this
+  %51 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
+  %52 = load %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
+  %53 = load %System.Text.StringBuilder addrspace(1)** %this
+  %54 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
+  %55 = load i32 addrspace(1)* %54, align 8
+  %56 = load i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
+  %57 = load %System.Text.StringBuilder addrspace(1)** %this
+  %58 = load %System.Text.StringBuilder addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
+  %60 = load %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
+  %61 = getelementptr inbounds %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
+  %62 = load i32 addrspace(1)* %61
+  %63 = zext i32 %62 to i64
+  %64 = trunc i64 %63 to i32
+  %65 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  store i32 %64, i32 addrspace(1)* %65
+  br label %66
+
+; <label>:66                                      ; preds = %34, %48
+  %67 = load i32* %arg2
+  %68 = load i32* %loc1
+  %69 = sub i32 %67, %68
+  store i32 %69, i32* %loc2
+  %70 = load %System.Text.StringBuilder addrspace(1)** %this
+  %71 = load i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
+  %72 = load i16** %arg1
+  %73 = load i32* %loc1
+  %74 = sext i32 %73 to i64
+  %75 = mul i64 %74, 2
+  %76 = bitcast i16* %72 to i8*
+  %77 = getelementptr inbounds i8* %76, i64 %75
+  %78 = load %System.Text.StringBuilder addrspace(1)** %this
+  %79 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
+  %80 = load %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
+  %81 = load i32* %loc2
+  %82 = bitcast i8* %77 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
+  %83 = load %System.Text.StringBuilder addrspace(1)** %this
+  %84 = load i32* %loc2
+  %85 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
+  store i32 %84, i32 addrspace(1)* %85
+  br label %86
+
+; <label>:86                                      ; preds = %22, %66
+  %87 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %87
+}
+
+INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
+Successfully read StringBuilder.ExpandByABlock
+
+define void @StringBuilder.ExpandByABlock(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg1
+  %1 = load %System.Text.StringBuilder addrspace(1)** %this
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
+  %3 = add i32 %0, %2
+  %4 = load %System.Text.StringBuilder addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %6 = load i32 addrspace(1)* %5, align 8
+  %7 = icmp sle i32 %3, %6
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %entry
+  %14 = load i32* %arg1
+  %15 = load %System.Text.StringBuilder addrspace(1)** %this
+  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
+  store i32 %18, i32* %loc0
+  %19 = load %System.Text.StringBuilder addrspace(1)** %this
+  %20 = load %System.Text.StringBuilder addrspace(1)** %this
+  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
+  %22 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %23 = load %System.Text.StringBuilder addrspace(1)** %this
+  %24 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %25 = load i32 addrspace(1)* %24, align 8
+  %26 = load %System.Text.StringBuilder addrspace(1)** %this
+  %27 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
+  %28 = load i32 addrspace(1)* %27, align 8
+  %29 = add i32 %25, %28
+  %30 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  store i32 %29, i32 addrspace(1)* %30
+  %31 = load %System.Text.StringBuilder addrspace(1)** %this
+  %32 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %32
+  %33 = load %System.Text.StringBuilder addrspace(1)** %this
+  %34 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
+  %35 = load i32 addrspace(1)* %34, align 8
+  %36 = load i32* %loc0
+  %37 = add i32 %35, %36
+  %38 = load i32* %loc0
+  %39 = icmp sge i32 %37, %38
+  br i1 %39, label %44, label %40
+
+; <label>:40                                      ; preds = %13
+  %41 = load %System.Text.StringBuilder addrspace(1)** %this
+  %42 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
+  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+  unreachable
+
+; <label>:44                                      ; preds = %13
+  %45 = load %System.Text.StringBuilder addrspace(1)** %this
+  %46 = load i32* %loc0
+  %47 = sext i32 %46 to i64
+  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
+  %49 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+  ret void
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = load %System.Text.StringBuilder addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = add i32 %2, %5
+  ret i32 %6
+}
+
+INFO:  jitting method Math::Max using LLILCJit
+Successfully read Math.Max
+
+define i32 @Math.Max(i32 %param0, i32 %param1) {
+entry:
+  %arg0 = alloca i32
+  %arg1 = alloca i32
+  store i32 %param0, i32* %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg0
+  %1 = load i32* %arg1
+  %2 = icmp sge i32 %0, %1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i32* %arg1
+  ret i32 %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32* %arg0
+  ret i32 %6
+}
+
+INFO:  jitting method StringBuilder::.ctor using LLILCJit
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %param1, %System.Text.StringBuilder addrspace(1)** %arg1
+  %0 = load %System.Text.StringBuilder addrspace(1)** %this
+  %1 = bitcast %System.Text.StringBuilder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Text.StringBuilder addrspace(1)** %this
+  %3 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %5, i32 addrspace(1)* %6
+  %7 = load %System.Text.StringBuilder addrspace(1)** %this
+  %8 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %9 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32 addrspace(1)* %9, align 8
+  %11 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
+  store i32 %10, i32 addrspace(1)* %11
+  %12 = load %System.Text.StringBuilder addrspace(1)** %this
+  %13 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %14 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
+  %15 = load %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
+  %16 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
+  %17 = load %System.Text.StringBuilder addrspace(1)** %this
+  %18 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %19 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
+  %20 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  %21 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
+  %22 = load %System.Text.StringBuilder addrspace(1)** %this
+  %23 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %24 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
+  %25 = load i32 addrspace(1)* %24, align 8
+  %26 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
+  store i32 %25, i32 addrspace(1)* %26
+  ret void
+}
+
+INFO:  jitting method StringBuilder::Append using LLILCJit
+Failed to read StringBuilder.Append[storeElem]
+INFO:  jitting method StringBuilder::Remove using LLILCJit
+Successfully read StringBuilder.Remove
+
+define %System.Text.StringBuilder addrspace(1)* @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc1 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32* %arg2
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg1
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32* %arg2
+  %17 = load %System.Text.StringBuilder addrspace(1)** %this
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %17)
+  %19 = load i32* %arg1
+  %20 = sub i32 %18, %19
+  %21 = icmp sle i32 %16, %20
+  br i1 %21, label %27, label %22
+
+; <label>:22                                      ; preds = %15
+  %23 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
+  unreachable
+
+; <label>:27                                      ; preds = %15
+  %28 = load %System.Text.StringBuilder addrspace(1)** %this
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %28)
+  %30 = load i32* %arg2
+  %31 = icmp ne i32 %29, %30
+  br i1 %31, label %38, label %32
+
+; <label>:32                                      ; preds = %27
+  %33 = load i32* %arg1
+  %34 = icmp ne i32 %33, 0
+  br i1 %34, label %38, label %35
+
+; <label>:35                                      ; preds = %32
+  %36 = load %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %36, i32 0)
+  %37 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %37
+
+; <label>:38                                      ; preds = %27, %32
+  %39 = load i32* %arg2
+  %40 = icmp sle i32 %39, 0
+  br i1 %40, label %47, label %41
+
+; <label>:41                                      ; preds = %38
+  %42 = load %System.Text.StringBuilder addrspace(1)** %this
+  %43 = load i32* %arg1
+  %44 = load i32* %arg2
+  %45 = addrspacecast %System.Text.StringBuilder addrspace(1)** %loc0 to %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %46 = addrspacecast i32* %loc1 to i32 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32, i32, %System.Text.StringBuilder addrspace(1)* addrspace(1)*, i32 addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %42, i32 %43, i32 %44, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, i32 addrspace(1)* %46)
+  br label %47
+
+; <label>:47                                      ; preds = %38, %41
+  %48 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %48
+}
+
+INFO:  jitting method StringBuilder::Remove using LLILCJit
+Failed to read StringBuilder.Remove[Tail call]
+INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
+Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+INFO:  jitting method Buffer::_Memmove using LLILCJit
+Failed to read Buffer._Memmove[Tail call]
+INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
+Failed to read AppDomain.SetDataHelper[loadElem]
+INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
+Successfully read AppDomain.get_LocalStore
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* @AppDomain.get_LocalStore(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.AppDomain addrspace(1)** %this
+  %6 = getelementptr inbounds %System.AppDomain addrspace(1)* %5, i32 0, i32 2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
+  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %12 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)** %this
+  %14 = getelementptr inbounds %System.AppDomain addrspace(1)* %13, i32 0, i32 2
+  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+}
+
+INFO:  jitting method Dictionary`2::.ctor using LLILCJit
+Failed to read Dictionary`2..ctor[Tail call]
+INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
+Failed to read Dictionary`2.TryGetValue[loadElemA]
+INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
+Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+INFO:  jitting method Path::NormalizePath using LLILCJit
+Failed to read Path.NormalizePath[Tail call]
+INFO:  jitting method StringBuilder::.ctor using LLILCJit
+Failed to read StringBuilder..ctor[Tail call]
+INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
+Failed to read HashHelpers.ExpandPrime[Tail call]
+INFO:  jitting method Dictionary`2::Resize using LLILCJit
+Failed to read Dictionary`2.Resize[non-const derefAddress]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
+Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
+INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
+Successfully read AppDomain.get_FusionStore
+
+define %System.AppDomainSetup addrspace(1)* @AppDomain.get_FusionStore(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.AppDomainSetup addrspace(1)* %2
+}
+
+INFO:  jitting method AppDomain::GetData using LLILCJit
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
+INFO:  jitting method AppDomainSetup::Locate using LLILCJit
+Successfully read AppDomainSetup.Locate
+
+define i32 @AppDomainSetup.Locate(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i32 -1
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** %arg0
+  %7 = getelementptr inbounds %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %8 = load i16 addrspace(1)* %7
+  %9 = zext i16 %8 to i32
+  %10 = icmp ne i32 %9, 65
+  br i1 %10, label %18, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)** %arg0
+  %13 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %18, label %17
+
+; <label>:17                                      ; preds = %11
+  ret i32 0
+
+; <label>:18                                      ; preds = %5, %11
+  ret i32 -1
+}
+
+INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimizationKey
+
+define %System.String addrspace(1)* @AppDomainSetup.get_LoaderOptimizationKey() {
+entry:
+  %0 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %0
+}
+
+INFO:  jitting method String::Equals using LLILCJit
+Failed to read String.Equals[Tail call]
+INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
+Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
+Failed to read AppDomain.SetupBindingPaths[Tail call]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
+Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
+INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
+Successfully read AppDomain.GetNativeHandle
+
+define %System.AppDomainHandle @AppDomain.GetNativeHandle(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %0 = alloca %System.AppDomainHandle
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %1 = load %System.AppDomain addrspace(1)** %this
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomain addrspace(1)* %1, i32 0, i32 15
+  %4 = bitcast i64 addrspace(1)* %3 to %System.IntPtr addrspace(1)*
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.IntPtr addrspace(1)*)*)(%System.IntPtr addrspace(1)* %4)
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %2
+  %9 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %11) #1
+  unreachable
+
+; <label>:12                                      ; preds = %2
+  %13 = load %System.AppDomain addrspace(1)** %this
+  %14 = getelementptr inbounds %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %15 = load i64 addrspace(1)* %14, align 8
+  %16 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
+  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
+  %18 = load %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %18
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+}
+
+INFO:  jitting method IntPtr::IsNull using LLILCJit
+Successfully read IntPtr.IsNull
+
+define i8 @IntPtr.IsNull(%System.IntPtr addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IntPtr addrspace(1)*
+  store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
+  %0 = load %System.IntPtr addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %2 = load i16* addrspace(1)* %1, align 8
+  %3 = ptrtoint i16* %2 to i64
+  %4 = icmp eq i64 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
+INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
+Successfully read AppDomainHandle..ctor
+
+define void @AppDomainHandle..ctor(%System.AppDomainHandle addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.AppDomainHandle addrspace(1)*
+  %arg1 = alloca i64
+  store %System.AppDomainHandle addrspace(1)* %param0, %System.AppDomainHandle addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.AppDomainHandle addrspace(1)** %this
+  %1 = load i64* %arg1
+  %2 = getelementptr inbounds %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %2
+  ret void
+}
+
+INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+INFO:  jitting method Dictionary`2::.ctor using LLILCJit
+Failed to read Dictionary`2..ctor[non-const derefAddress]
+INFO:  jitting method Dictionary`2::get_Count using LLILCJit
+Successfully read Dictionary`2.get_Count
+
+define i32 @"Dictionary`2.get_Count"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = sub i32 %2, %5
+  ret i32 %6
+}
+
+INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
+Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
+INFO:  jitting method Enumerator::MoveNext using LLILCJit
+Failed to read Enumerator.MoveNext[loadElemA]
+INFO:  jitting method Enumerator::get_Current using LLILCJit
+Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
+INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
+Failed to read OrdinalComparer.GetHashCode[Tail call]
+INFO:  jitting method TextInfo::get_Invariant using LLILCJit
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
+INFO:  jitting method TextInfo::.ctor using LLILCJit
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
+Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+INFO:  jitting method Enumerator::Dispose using LLILCJit
+Successfully read Enumerator.Dispose
+
+define void @Enumerator.Dispose(%"System.Collections.Generic.Dictionary`2+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::InitializeSwitches using LLILCJit
+Successfully read CompatibilitySwitches.InitializeSwitches
+
+define void @CompatibilitySwitches.InitializeSwitches() {
+entry:
+  %0 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %5 = getelementptr inbounds i8 addrspace(1)* %4, i64 1989
+  %6 = addrspacecast i8 addrspace(1)* %5 to i8*
+  store i8 %3, i8* %6
+  %7 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1990
+  %13 = addrspacecast i8 addrspace(1)* %12 to i8*
+  store i8 %10, i8* %13
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1988
+  %20 = addrspacecast i8 addrspace(1)* %19 to i8*
+  store i8 %17, i8* %20
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %22 = getelementptr inbounds i8 addrspace(1)* %21, i64 1988
+  %23 = addrspacecast i8 addrspace(1)* %22 to i8*
+  %24 = load i8* %23
+  %25 = zext i8 %24 to i32
+  %26 = icmp ne i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %entry
+  %28 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  br label %32
+
+; <label>:31                                      ; preds = %entry
+  br label %32
+
+; <label>:32                                      ; preds = %27, %31
+  %33 = phi i32 [ %30, %27 ], [ 1, %31 ]
+  %34 = trunc i32 %33 to i8
+  %35 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %36 = getelementptr inbounds i8 addrspace(1)* %35, i64 1987
+  %37 = addrspacecast i8 addrspace(1)* %36 to i8*
+  store i8 %34, i8* %37
+  %38 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %39 = getelementptr inbounds i8 addrspace(1)* %38, i64 1986
+  %40 = addrspacecast i8 addrspace(1)* %39 to i8*
+  store i8 1, i8* %40
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
+INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
+INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalGetApplicationTrust
+
+define %System.Security.Policy.ApplicationTrust addrspace(1)* @AppDomainSetup.InternalGetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
+  %8 = load %System.String addrspace(1)* addrspace(1)* %7, align 8
+  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+}
+
+INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Failed to read PermissionSet..ctor[Tail call]
+INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
+Successfully read ApplicationTrust..ctor
+
+define void @ApplicationTrust..ctor(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.ApplicationTrust addrspace(1)* %0 to %System.Security.Policy.EvidenceBase addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.EvidenceBase addrspace(1)*)*)(%System.Security.Policy.EvidenceBase addrspace(1)* %1)
+  %2 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %3 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %2, %System.Security.PermissionSet addrspace(1)* %3)
+  %4 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %5 = call %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
+  %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
+  %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  ret void
+}
+
+INFO:  jitting method EvidenceBase::.ctor using LLILCJit
+Failed to read EvidenceBase..ctor[Tail call]
+INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
+Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 72
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 32
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Copy using LLILCJit
+Successfully read PermissionSet.Copy
+
+define %System.Security.PermissionSet addrspace(1)* @PermissionSet.Copy(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)** %this
+  %1 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %1, %System.Security.PermissionSet addrspace(1)* %0)
+  ret %System.Security.PermissionSet addrspace(1)* %1
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Failed to read PermissionSet..ctor[Tail call]
+INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
+Successfully read PolicyStatement.ValidProperties
+
+define i8 @PolicyStatement.ValidProperties(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32* %arg0
+  %1 = and i32 %0, -4
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %5)
+  %7 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %7, %System.String addrspace(1)* %6)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %7) #0
+  unreachable
+}
+
+INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
+Successfully read PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca i8
+  %loc1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc2 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc0
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc0 to i8 addrspace(1)*
+  %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %5 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64 addrspace(1)* %6
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64* %9
+  %11 = add i64 %10, 32
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64* %12
+  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
+  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = load i8* %loc0
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %16
+  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
+  br label %23
+
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
+  %25 = load %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %25
+}
+
+INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
+INFO:  jitting method List`1::.ctor using LLILCJit
+Failed to read List`1..ctor[non-const derefAddress]
+INFO:  jitting method List`1::AsReadOnly using LLILCJit
+Failed to read List`1.AsReadOnly[non-const derefAddress]
+INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
+Successfully read ReadOnlyCollection`1..ctor
+
+define void @"ReadOnlyCollection`1..ctor"(%"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  store %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %param1, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %0 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %3 = icmp ne %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 7)
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
+INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
+Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
+INFO:  jitting method AppDomain::RunInitializer using LLILCJit
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Failed to read PermissionSet..ctor[Tail call]
+INFO:  jitting method BringUpTest::Main using LLILCJit
+Failed to read BringUpTest.Main[abs]
+INFO:  jitting method BringUpTest::DblRem using LLILCJit
+Successfully read BringUpTest.DblRem
+
+define double @BringUpTest.DblRem(double %param0, double %param1) {
+entry:
+  %arg0 = alloca double
+  %arg1 = alloca double
+  store double %param0, double* %arg0
+  store double %param1, double* %arg1
+  %0 = load double* %arg0
+  %1 = load double* %arg1
+  %2 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (double, double)*)(double %0, double %1)
+  ret double %2
+}
+
+INFO:  jitting method Console::WriteLine using LLILCJit
+Failed to read Console.WriteLine[Tail call]
+INFO:  jitting method Console::get_Out using LLILCJit
+Failed to read Console.get_Out[Call HasTypeArg]
+INFO:  jitting method Console::.cctor using LLILCJit
+Successfully read Console..cctor
+
+define void @Console..cctor() {
+entry:
+  %0 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %0)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method Console::EnsureInitialized using LLILCJit
+Failed to read Console.EnsureInitialized[Call HasTypeArg]
+INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
+Failed to read Console.<get_Out>b__2[Tail call]
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
+Successfully read ConsolePal.GetStandardFile
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.GetStandardFile(i64 %param0, i32 %param1) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca i32
+  store i64 %param0, i64* %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i64* %arg0
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %0, i64 0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %18, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64* %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  %6 = load i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %5, i64 %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %4
+  %11 = load i32* %arg1
+  %12 = icmp eq i32 %11, 1
+  br i1 %12, label %20, label %13
+
+; <label>:13                                      ; preds = %10
+  %14 = load i64* %arg0
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64)*)(i64 %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %entry, %4, %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %19 = load %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  ret %System.IO.Stream addrspace(1)* %19
+
+; <label>:20                                      ; preds = %10, %13
+  %21 = load i64* %arg0
+  %22 = load i32* %arg1
+  %23 = call %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, i64, i32)*)(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %23, i64 %21, i32 %22)
+  %24 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %23 to %System.IO.Stream addrspace(1)*
+  ret %System.IO.Stream addrspace(1)* %24
+}
+
+INFO:  jitting method IntPtr::op_Equality using LLILCJit
+Successfully read IntPtr.op_Equality
+
+define i8 @IntPtr.op_Equality(i64 %param0, i64 %param1) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca i64
+  store i64 %param0, i64* %arg0
+  store i64 %param1, i64* %arg1
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16* addrspace(1)* %3, align 8
+  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
+  %7 = getelementptr inbounds i8 addrspace(1)* %6, i64 0
+  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
+  %9 = load i16* addrspace(1)* %8, align 8
+  %10 = icmp eq i16* %4, %9
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  ret i8 %12
+}
+
+INFO:  jitting method Interop::.cctor using LLILCJit
+Successfully read Interop..cctor
+
+define void @Interop..cctor() {
+entry:
+  %0 = alloca i64
+  %1 = bitcast i64* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %1, i8 0, i64 0, i32 0, i1 false)
+  %2 = addrspacecast i64* %0 to i64 addrspace(1)*
+  %3 = bitcast i64 addrspace(1)* %2 to %System.IntPtr addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IntPtr addrspace(1)*, i32)*)(%System.IntPtr addrspace(1)* %3, i32 -1)
+  %4 = load i64* %0
+  store i64 %4, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  ret void
+}
+
+INFO:  jitting method IntPtr::.ctor using LLILCJit
+Successfully read IntPtr..ctor
+
+define void @IntPtr..ctor(%System.IntPtr addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IntPtr addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IntPtr addrspace(1)** %this
+  %1 = load i32* %arg1
+  %2 = sext i32 %1 to i64
+  %3 = inttoptr i64 %2 to i16*
+  %4 = getelementptr inbounds %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
+Successfully read ConsolePal.ConsoleHandleIsWritable
+
+define i8 @ConsolePal.ConsoleHandleIsWritable(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  %loc0 = alloca i32
+  %loc1 = alloca i8
+  store i64 %param0, i64* %arg0
+  store i8 65, i8* %loc1
+  %0 = load i64* %arg0
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = ptrtoint i8 addrspace(1)* %1 to i64
+  %3 = addrspacecast i32* %loc0 to i32 addrspace(1)*
+  %4 = inttoptr i64 %2 to i8*
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %0, i8* %4, i32 0, i32 addrspace(1)* %3, i64 0)
+  %6 = icmp ugt i32 %5, 0
+  %7 = sext i1 %6 to i32
+  %8 = trunc i32 %7 to i8
+  ret i8 %8
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
+Successfully read WindowsConsoleStream..ctor
+
+define void @WindowsConsoleStream..ctor(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, i64 %param1, i32 %param2) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  %arg1 = alloca i64
+  %arg2 = alloca i32
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = load i32* %arg2
+  %2 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
+  %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %4 = load i64* %arg1
+  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %5
+  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %7 = load i64* %arg1
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
+  %9 = icmp eq i32 %8, 3
+  %10 = sext i1 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
+  store i8 %11, i8 addrspace(1)* %12
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::.ctor using LLILCJit
+Successfully read ConsoleStream..ctor
+
+define void @ConsoleStream..ctor(%System.IO.ConsoleStream addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  %2 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %3 = load i32* %arg1
+  %4 = and i32 %3, 1
+  %5 = icmp eq i32 %4, 1
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  %8 = getelementptr inbounds %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %8
+  %9 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %10 = load i32* %arg1
+  %11 = and i32 %10, 2
+  %12 = icmp eq i32 %11, 2
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  %15 = getelementptr inbounds %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
+  store i8 %14, i8 addrspace(1)* %15
+  ret void
+}
+
+INFO:  jitting method Stream::.ctor using LLILCJit
+Failed to read Stream..ctor[Tail call]
+INFO:  jitting method mincore::GetFileType using LLILCJit
+Failed to read mincore.GetFileType[Tail call]
+INFO:  jitting method Console::CreateOutputWriter using LLILCJit
+Failed to read Console.CreateOutputWriter[Tail call]
+INFO:  jitting method Stream::.cctor using LLILCJit
+Successfully read Stream..cctor
+
+define void @Stream..cctor() {
+entry:
+  %0 = call %"System.IO.Stream+NullStream" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.IO.Stream+NullStream" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.IO.Stream+NullStream" addrspace(1)*)*)(%"System.IO.Stream+NullStream" addrspace(1)* %0)
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %2 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %3 = getelementptr inbounds i8 addrspace(1)* %2, i64 2680
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(i8 addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method NullStream::.ctor using LLILCJit
+Failed to read NullStream..ctor[Tail call]
+INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
+Failed to read mincore.GetConsoleOutputCP[Tail call]
+INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
+Successfully read ConsolePal.GetEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.GetEncoding(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %System.Text.Encoding addrspace(1)*
+  store i32 %param0, i32* %arg0
+  %0 = load i32* %arg0
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  store %System.Text.Encoding addrspace(1)* %1, %System.Text.Encoding addrspace(1)** %loc0
+  %2 = load %System.Text.Encoding addrspace(1)** %loc0
+  %3 = call %System.Text.ConsoleEncoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.ConsoleEncoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.ConsoleEncoding addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.ConsoleEncoding addrspace(1)* %3, %System.Text.Encoding addrspace(1)* %2)
+  %4 = bitcast %System.Text.ConsoleEncoding addrspace(1)* %3 to %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %4, %System.Text.Encoding addrspace(1)** %loc0
+  br label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.Encoding addrspace(1)** %loc0
+  ret %System.Text.Encoding addrspace(1)* %6
+}
+
+INFO:  jitting method Encoding::GetEncoding using LLILCJit
+Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
+INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
+Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+INFO:  jitting method EncodingProvider::.cctor using LLILCJit
+Successfully read EncodingProvider..cctor
+
+define void @EncodingProvider..cctor() {
+entry:
+  %0 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 2384
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Object addrspace(1)*)*)(i8 addrspace(1)* %2, %System.Object addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_InternalSyncObject using LLILCJit
+Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
+INFO:  jitting method Hashtable::.ctor using LLILCJit
+Failed to read Hashtable..ctor[Volatile store]
+INFO:  jitting method Hashtable::get_Item using LLILCJit
+Failed to read Hashtable.get_Item[loadElemA]
+INFO:  jitting method Hashtable::InitHash using LLILCJit
+Successfully read Hashtable.InitHash
+
+define i32 @Hashtable.InitHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, i32 %param2, i32 addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32 addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 addrspace(1)* %param3, i32 addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)** %arg1
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64 addrspace(1)* %2
+  %4 = add i64 %3, 72
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64* %8
+  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %12 = and i32 %11, 2147483647
+  store i32 %12, i32* %loc0
+  %13 = load i32 addrspace(1)** %arg3
+  %14 = load i32* %loc0
+  store i32 %14, i32 addrspace(1)* %13, align 8
+  %15 = load i32 addrspace(1)** %arg4
+  %16 = load i32 addrspace(1)** %arg3
+  %17 = load i32 addrspace(1)* %16, align 8
+  %18 = mul i32 %17, 101
+  %19 = load i32* %arg2
+  %20 = sub i32 %19, 1
+  %21 = urem i32 %18, %20
+  %22 = add i32 1, %21
+  store i32 %22, i32 addrspace(1)* %15, align 8
+  %23 = load i32* %loc0
+  ret i32 %23
+}
+
+INFO:  jitting method Hashtable::GetHash using LLILCJit
+Failed to read Hashtable.GetHash[Tail call]
+INFO:  jitting method Int32::GetHashCode using LLILCJit
+Successfully read Int32.GetHashCode
+
+define i32 @Int32.GetHashCode(%System.Int32 addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  %0 = load %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32* %1, align 8
+  ret i32 %2
+}
+
+INFO:  jitting method Encoding::get_UTF8 using LLILCJit
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
+INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
+Successfully read UTF8Encoding.SetDefaultFallbacks
+
+define void @UTF8Encoding.SetDefaultFallbacks(%System.Text.UTF8Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  %0 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %8 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
+  %9 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+  ret void
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
+  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
+  %17 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
+  %18 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
+  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
+  %22 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+  ret void
+}
+
+INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
+Failed to read EncoderReplacementFallback..ctor[storeElem]
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Failed to read Char.IsSurrogate[Tail call]
+INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
+Failed to read DecoderReplacementFallback..ctor[storeElem]
+INFO:  jitting method Hashtable::Add using LLILCJit
+Failed to read Hashtable.Add[Tail call]
+INFO:  jitting method Hashtable::Insert using LLILCJit
+Failed to read Hashtable.Insert[loadElemA]
+INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
+Successfully read ConsoleEncoding..ctor
+
+define void @ConsoleEncoding..ctor(%System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = bitcast %System.Text.ConsoleEncoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
+  %2 = load %System.Text.ConsoleEncoding addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Failed to read Encoding..ctor[Tail call]
+INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
+Successfully read Encoding.SetDefaultFallbacks
+
+define void @Encoding.SetDefaultFallbacks(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)** %this
+  %1 = load %System.Text.Encoding addrspace(1)** %this
+  %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
+  %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
+  %4 = getelementptr inbounds %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
+  %5 = load %System.Text.Encoding addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)** %this
+  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
+  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
+  %9 = getelementptr inbounds %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
+Successfully read InternalEncoderBestFitFallback..ctor
+
+define void @InternalEncoderBestFitFallback..ctor(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.InternalEncoderBestFitFallback addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.InternalEncoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %0 to %System.Text.EncoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
+  %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
+INFO:  jitting method EncoderFallback::.ctor using LLILCJit
+Failed to read EncoderFallback..ctor[Tail call]
+INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
+Successfully read InternalDecoderBestFitFallback..ctor
+
+define void @InternalDecoderBestFitFallback..ctor(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.InternalDecoderBestFitFallback addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %1
+  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
+  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)** %arg1
+  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
+  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
+  ret void
+}
+
+INFO:  jitting method DecoderFallback::.ctor using LLILCJit
+Failed to read DecoderFallback..ctor[Tail call]
+INFO:  jitting method StreamWriter::.ctor using LLILCJit
+Failed to read StreamWriter..ctor[Tail call]
+INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
+Successfully read ConsoleStream.get_CanWrite
+
+define i8 @ConsoleStream.get_CanWrite(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
+INFO:  jitting method StreamWriter::Init using LLILCJit
+Successfully read StreamWriter.Init
+
+define void @StreamWriter.Init(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = load %System.IO.Stream addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
+  %3 = load %System.IO.StreamWriter addrspace(1)** %this
+  %4 = load %System.Text.Encoding addrspace(1)** %arg2
+  %5 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
+  %6 = load %System.IO.StreamWriter addrspace(1)** %this
+  %7 = load %System.IO.StreamWriter addrspace(1)** %this
+  %8 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
+  %9 = load %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64 addrspace(1)* %10
+  %12 = add i64 %11, 96
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64* %16
+  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
+  %20 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
+  %21 = load i32* %arg3
+  %22 = icmp sge i32 %21, 128
+  br i1 %22, label %24, label %23
+
+; <label>:23                                      ; preds = %entry
+  store i32 128, i32* %arg3
+  br label %24
+
+; <label>:24                                      ; preds = %entry, %23
+  %25 = load %System.IO.StreamWriter addrspace(1)** %this
+  %26 = load i32* %arg3
+  %27 = sext i32 %26 to i64
+  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
+  %29 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %30 = load %System.IO.StreamWriter addrspace(1)** %this
+  %31 = load %System.IO.StreamWriter addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
+  %33 = load %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
+  %34 = load i32* %arg3
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
+  %36 = load i64 addrspace(1)* %35
+  %37 = add i64 %36, 96
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64* %38
+  %40 = add i64 %39, 16
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64* %41
+  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
+  %45 = sext i32 %44 to i64
+  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
+  %47 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)** %this
+  %49 = load i32* %arg3
+  %50 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
+  store i32 %49, i32 addrspace(1)* %50
+  %51 = load %System.IO.StreamWriter addrspace(1)** %this
+  %52 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
+  %53 = load %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
+  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
+  %55 = load i64 addrspace(1)* %54
+  %56 = add i64 %55, 64
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64* %57
+  %59 = add i64 %58, 40
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64* %60
+  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
+  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %84, label %66
+
+; <label>:66                                      ; preds = %24
+  %67 = load %System.IO.StreamWriter addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
+  %69 = load %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64 addrspace(1)* %70
+  %72 = add i64 %71, 72
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64* %73
+  %75 = add i64 %74, 8
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64* %76
+  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
+  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
+  %80 = icmp sle i64 %79, 0
+  br i1 %80, label %84, label %81
+
+; <label>:81                                      ; preds = %66
+  %82 = load %System.IO.StreamWriter addrspace(1)** %this
+  %83 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %83
+  br label %84
+
+; <label>:84                                      ; preds = %24, %66, %81
+  %85 = load %System.IO.StreamWriter addrspace(1)** %this
+  %86 = load i8* %arg4
+  %87 = zext i8 %86 to i32
+  %88 = icmp eq i32 %87, 0
+  %89 = sext i1 %88 to i32
+  %90 = trunc i32 %89 to i8
+  %91 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
+  store i8 %90, i8 addrspace(1)* %91
+  ret void
+}
+
+INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
+Failed to read ConsoleEncoding.GetEncoder[Tail call]
+INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
+Successfully read UTF8Encoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @UTF8Encoding.GetEncoder(%System.Text.UTF8Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  %0 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = call %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)*)*)(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %1, %System.Text.UTF8Encoding addrspace(1)* %0)
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %1 to %System.Text.Encoder addrspace(1)*
+  ret %System.Text.Encoder addrspace(1)* %2
+}
+
+INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
+Failed to read UTF8Encoder..ctor[Tail call]
+INFO:  jitting method UTF8Encoder::Reset using LLILCJit
+Failed to read UTF8Encoder.Reset[Tail call]
+INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
+Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
+Successfully read UTF8Encoding.GetMaxByteCount
+
+define i32 @UTF8Encoding.GetMaxByteCount(%System.Text.UTF8Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i64
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg1
+  %9 = sext i32 %8 to i64
+  %10 = add i64 %9, 1
+  store i64 %10, i64* %loc0
+  %11 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
+  %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64* %20
+  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
+  %24 = icmp sle i32 %23, 1
+  br i1 %24, label %42, label %25
+
+; <label>:25                                      ; preds = %7
+  %26 = load i64* %loc0
+  %27 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
+  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
+  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64 addrspace(1)* %30
+  %32 = add i64 %31, 64
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64* %33
+  %35 = add i64 %34, 40
+  %36 = inttoptr i64 %35 to i64*
+  %37 = load i64* %36
+  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
+  %40 = sext i32 %39 to i64
+  %41 = mul i64 %26, %40
+  store i64 %41, i64* %loc0
+  br label %42
+
+; <label>:42                                      ; preds = %7, %25
+  %43 = load i64* %loc0
+  %44 = mul i64 %43, 3
+  store i64 %44, i64* %loc0
+  %45 = load i64* %loc0
+  %46 = icmp sle i64 %45, 2147483647
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %42
+  %48 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
+  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+  unreachable
+
+; <label>:52                                      ; preds = %42
+  %53 = load i64* %loc0
+  %54 = trunc i64 %53 to i32
+  ret i32 %54
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
+INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
+Successfully read EncoderReplacementFallback.get_MaxCharCount
+
+define i32 @EncoderReplacementFallback.get_MaxCharCount(%System.Text.EncoderReplacementFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
+  store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderReplacementFallback addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32 addrspace(1)* %3
+  ret i32 %4
+}
+
+INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
+Successfully read ConsoleStream.get_CanSeek
+
+define i8 @ConsoleStream.get_CanSeek(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  ret i8 0
+}
+
+INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
+Failed to read StreamWriter.set_AutoFlush[Tail call]
+INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
+Successfully read StreamWriter.CheckAsyncTaskInProgress
+
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
+  ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
+INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
+Successfully read SyncTextWriter.GetSynchronizedTextWriter
+
+define %System.IO.TextWriter addrspace(1)* @SyncTextWriter.GetSynchronizedTextWriter(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %arg0
+  %0 = load %System.IO.TextWriter addrspace(1)** %arg0
+  %1 = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.TextWriter addrspace(1)** %arg0
+  %7 = call %System.IO.SyncTextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.SyncTextWriter addrspace(1)* (i64, %System.IO.TextWriter addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.IO.TextWriter addrspace(1)* %6)
+  %8 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %7, null
+  br i1 %8, label %13, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = load %System.IO.TextWriter addrspace(1)** %arg0
+  %11 = call %System.IO.SyncTextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.SyncTextWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.SyncTextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.SyncTextWriter addrspace(1)* %11, %System.IO.TextWriter addrspace(1)* %10)
+  %12 = bitcast %System.IO.SyncTextWriter addrspace(1)* %11 to %System.IO.TextWriter addrspace(1)*
+  ret %System.IO.TextWriter addrspace(1)* %12
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.IO.TextWriter addrspace(1)** %arg0
+  ret %System.IO.TextWriter addrspace(1)* %14
+}
+
+INFO:  jitting method SyncTextWriter::.ctor using LLILCJit
+Successfully read SyncTextWriter..ctor
+
+define void @SyncTextWriter..ctor(%System.IO.SyncTextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.SyncTextWriter addrspace(1)*
+  %arg1 = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.SyncTextWriter addrspace(1)* %param0, %System.IO.SyncTextWriter addrspace(1)** %this
+  store %System.IO.TextWriter addrspace(1)* %param1, %System.IO.TextWriter addrspace(1)** %arg1
+  %0 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
+  %3 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %4 = load %System.IO.TextWriter addrspace(1)** %arg1
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64 addrspace(1)* %5
+  %7 = add i64 %6, 64
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64* %8
+  %10 = add i64 %9, 32
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64* %11
+  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
+  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
+  %16 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %17 = load %System.IO.TextWriter addrspace(1)** %arg1
+  %18 = getelementptr inbounds %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  ret void
+}
+
+INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
+INFO:  jitting method Object::Finalize using LLILCJit
+Successfully read Object.Finalize
+
+define void @Object.Finalize(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method CriticalFinalizerObject::Finalize using LLILCJit
+Successfully read CriticalFinalizerObject.Finalize
+
+define void @CriticalFinalizerObject.Finalize(%System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)*
+  store %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)* %param0, %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)** %this
+  br label %0
+
+; <label>:0                                       ; preds = %entry
+  %1 = load %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)** %this
+  %2 = bitcast %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2)
+  br label %3
+
+; <label>:3                                       ; preds = %0
+  ret void
+}
+
+INFO:  jitting method Thread::Finalize using LLILCJit
+Successfully read Thread.Finalize
+
+define void @Thread.Finalize(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = load %System.Threading.Thread addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %0)
+  br label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = load %System.Threading.Thread addrspace(1)** %this
+  %3 = bitcast %System.Threading.Thread addrspace(1)* %2 to %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)*)*)(%System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)* %3)
+  br label %4
+
+; <label>:4                                       ; preds = %1
+  ret void
+}
+
+INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
+Failed to read Thread.get_CurrentCulture[Tail call]
+INFO:  jitting method AppDomain::get_Flags using LLILCJit
+Successfully read AppDomain.get_Flags
+
+define i32 @AppDomain.get_Flags() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 123)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1980
+  %2 = addrspacecast i8 addrspace(1)* %1 to i32*
+  %3 = load i32* %2
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 123)
+  %8 = getelementptr inbounds i8 addrspace(1)* %7, i64 1980
+  %9 = addrspacecast i8 addrspace(1)* %8 to i32*
+  store i32 %6, i32* %9
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 123)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1980
+  %13 = addrspacecast i8 addrspace(1)* %12 to i32*
+  %14 = load i32* %13
+  ret i32 %14
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
+Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
+INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
+Successfully read SyncTextWriter.WriteLine
+
+define void @SyncTextWriter.WriteLine(%System.IO.SyncTextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.SyncTextWriter addrspace(1)*
+  %arg1 = alloca double
+  %loc0 = alloca %System.Object addrspace(1)*
+  %loc1 = alloca i8
+  store %System.IO.SyncTextWriter addrspace(1)* %param0, %System.IO.SyncTextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  store i8 0, i8* %loc1
+  %0 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.Object addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
+  %3 = load %System.Object addrspace(1)** %loc0
+  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
+  %5 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %6 = getelementptr inbounds %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load double* %arg1
+  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
+  %10 = load i64 addrspace(1)* %9
+  %11 = add i64 %10, 96
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64* %12
+  %14 = add i64 %13, 56
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64* %15
+  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
+  br label %18
+
+; <label>:18                                      ; preds = %entry
+  %19 = load i8* %loc1
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %18, %22
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  ret void
+}
+
+INFO:  jitting method TextWriter::WriteLine using LLILCJit
+Failed to read TextWriter.WriteLine[Tail call]
+INFO:  jitting method TextWriter::Write using LLILCJit
+Failed to read TextWriter.Write[Tail call]
+INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
+Failed to read NumberFormatInfo.GetInstance[Tail call]
+INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
+Successfully read CultureInfo.get_NumberFormat
+
+define %System.Globalization.NumberFormatInfo addrspace(1)* @CultureInfo.get_NumberFormat(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
+  br i1 %3, label %19, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
+  %7 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
+  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
+  %12 = load i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = trunc i32 %13 to i8
+  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
+  store i8 %14, i8 addrspace(1)* %15
+  %16 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %4
+  %20 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %21 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+}
+
+INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
+Failed to read NumberFormatInfo..ctor[storeElem]
+INFO:  jitting method CultureData::GetNFIValues using LLILCJit
+Successfully read CultureData.GetNFIValues
+
+define void @CultureData.GetNFIValues(%System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.NumberFormatInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %param1, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %65, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %8 = load %System.String addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
+  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %11 = load %System.Globalization.CultureData addrspace(1)** %this
+  %12 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
+  %13 = load %System.String addrspace(1)* addrspace(1)* %12, align 8
+  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
+  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %16 = load %System.Globalization.CultureData addrspace(1)** %this
+  %17 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
+  %18 = load %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %21 = load %System.Globalization.CultureData addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %26 = load %System.Globalization.CultureData addrspace(1)** %this
+  %27 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
+  %28 = load i32 addrspace(1)* %27, align 8
+  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
+  store i32 %28, i32 addrspace(1)* %29
+  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %31 = load %System.Globalization.CultureData addrspace(1)** %this
+  %32 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
+  %33 = load i32 addrspace(1)* %32, align 8
+  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
+  store i32 %33, i32 addrspace(1)* %34
+  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %36 = load %System.Globalization.CultureData addrspace(1)** %this
+  %37 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
+  %38 = load %System.String addrspace(1)* addrspace(1)* %37, align 8
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %40 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %41 = load %System.Globalization.CultureData addrspace(1)** %this
+  %42 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
+  %43 = load %System.String addrspace(1)* addrspace(1)* %42, align 8
+  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
+  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %46 = load %System.Globalization.CultureData addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
+  %48 = load %System.String addrspace(1)* addrspace(1)* %47, align 8
+  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
+  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %51 = load %System.Globalization.CultureData addrspace(1)** %this
+  %52 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
+  %53 = load i32 addrspace(1)* %52, align 8
+  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
+  store i32 %53, i32 addrspace(1)* %54
+  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %56 = load %System.Globalization.CultureData addrspace(1)** %this
+  %57 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
+  %58 = load i32 addrspace(1)* %57, align 8
+  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
+  store i32 %58, i32 addrspace(1)* %59
+  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %61 = load %System.Globalization.CultureData addrspace(1)** %this
+  %62 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
+  %63 = load i32 addrspace(1)* %62, align 8
+  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
+  store i32 %63, i32 addrspace(1)* %64
+  br label %76
+
+; <label>:65                                      ; preds = %entry
+  %66 = load %System.Globalization.CultureData addrspace(1)** %this
+  %67 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
+  %68 = load %System.String addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %70 = load %System.Globalization.CultureData addrspace(1)** %this
+  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
+  %72 = zext i8 %71 to i32
+  %73 = trunc i32 %72 to i8
+  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
+  %75 = zext i8 %74 to i32
+  br label %76
+
+; <label>:76                                      ; preds = %4, %65
+  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %78 = load %System.Globalization.CultureData addrspace(1)** %this
+  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
+  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
+  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %82 = load %System.Globalization.CultureData addrspace(1)** %this
+  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
+  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
+  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %86 = load %System.Globalization.CultureData addrspace(1)** %this
+  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
+  store i32 %87, i32 addrspace(1)* %88
+  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %90 = load %System.Globalization.CultureData addrspace(1)** %this
+  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
+  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
+  store i32 %91, i32 addrspace(1)* %92
+  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %94 = load %System.Globalization.CultureData addrspace(1)** %this
+  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
+  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
+  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %98 = load %System.Globalization.CultureData addrspace(1)** %this
+  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
+  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
+  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %102 = load %System.Globalization.CultureData addrspace(1)** %this
+  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
+  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
+  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %106 = load %System.Globalization.CultureData addrspace(1)** %this
+  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
+  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
+  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %110 = load %System.Globalization.CultureData addrspace(1)** %this
+  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
+  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
+  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
+  %116 = load i32 addrspace(1)* %115, align 8
+  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
+  store i32 %116, i32 addrspace(1)* %117
+  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
+  %121 = load %System.String addrspace(1)* addrspace(1)* %120, align 8
+  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
+  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
+  %126 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
+  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
+  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
+  %131 = load %System.String addrspace(1)* addrspace(1)* %130, align 8
+  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
+  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
+  %135 = load %System.String addrspace(1)* addrspace(1)* %134, align 8
+  %136 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %136, label %144, label %137
+
+; <label>:137                                     ; preds = %76
+  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
+  %140 = load %System.String addrspace(1)* addrspace(1)* %139, align 8
+  %141 = getelementptr inbounds %System.String addrspace(1)* %140, i32 0, i32 1
+  %142 = load i32 addrspace(1)* %141
+  %143 = icmp ne i32 %142, 0
+  br i1 %143, label %148, label %144
+
+; <label>:144                                     ; preds = %76, %137
+  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %146 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
+  br label %148
+
+; <label>:148                                     ; preds = %137, %144
+  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
+  %151 = load %System.String addrspace(1)* addrspace(1)* %150, align 8
+  %152 = icmp eq %System.String addrspace(1)* %151, null
+  br i1 %152, label %160, label %153
+
+; <label>:153                                     ; preds = %148
+  %154 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
+  %156 = load %System.String addrspace(1)* addrspace(1)* %155, align 8
+  %157 = getelementptr inbounds %System.String addrspace(1)* %156, i32 0, i32 1
+  %158 = load i32 addrspace(1)* %157
+  %159 = icmp ne i32 %158, 0
+  br i1 %159, label %166, label %160
+
+; <label>:160                                     ; preds = %148, %153
+  %161 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %162 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
+  %164 = load %System.String addrspace(1)* addrspace(1)* %163, align 8
+  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
+  br label %166
+
+; <label>:166                                     ; preds = %153, %160
+  ret void
+}
+
+INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
+Failed to read CultureData.get_IsInvariantCulture[Tail call]
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
+INFO:  jitting method CultureData::get_WAGROUPING using LLILCJit
+Successfully read CultureData.get_WAGROUPING
+
+define %"System.Int32[]" addrspace(1)* @CultureData.get_WAGROUPING(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %2 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
+  br i1 %3, label %10, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
+  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
+  %9 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %4
+  %11 = load %System.Globalization.CultureData addrspace(1)** %this
+  %12 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
+  %13 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
+  ret %"System.Int32[]" addrspace(1)* %13
+}
+
+INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
+Failed to read CultureData.DoGetLocaleInfo[Tail call]
+INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32* %arg2
+  %6 = or i32 %5, -2147483648
+  store i32 %6, i32* %arg2
+  br label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.String addrspace(1)** %arg1
+  %9 = load i32* %arg2
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %8, i32 %9)
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)** %loc0
+  %12 = icmp ne %System.String addrspace(1)* %11, null
+  br i1 %12, label %15, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc0
+  br label %15
+
+; <label>:15                                      ; preds = %7, %13
+  %16 = load %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %16
+}
+
+INFO:  jitting method CultureData::ConvertWin32GroupString using LLILCJit
+Failed to read CultureData.ConvertWin32GroupString[storeElem]
+INFO:  jitting method CultureData::get_WAMONGROUPING using LLILCJit
+Successfully read CultureData.get_WAMONGROUPING
+
+define %"System.Int32[]" addrspace(1)* @CultureData.get_WAMONGROUPING(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %2 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
+  br i1 %3, label %10, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
+  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
+  %9 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %4
+  %11 = load %System.Globalization.CultureData addrspace(1)** %this
+  %12 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
+  %13 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
+  ret %"System.Int32[]" addrspace(1)* %13
+}
+
+INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
+Successfully read CultureData.get_INEGATIVEPERCENT
+
+define i32 @CultureData.get_INEGATIVEPERCENT(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = icmp ne i32 %2, -1
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
+  store i32 %7, i32 addrspace(1)* %8
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
+  %12 = load i32 addrspace(1)* %11, align 8
+  ret i32 %12
+}
+
+INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
+Successfully read CultureData.DoGetLocaleInfoInt
+
+define i32 @CultureData.DoGetLocaleInfoInt(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32* %arg1
+  %6 = or i32 %5, -2147483648
+  store i32 %6, i32* %arg1
+  br label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %10 = load %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32* %arg1
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32* %loc0
+  ret i32 %13
+}
+
+INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
+Successfully read CultureData.get_IPOSITIVEPERCENT
+
+define i32 @CultureData.get_IPOSITIVEPERCENT(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = icmp ne i32 %2, -1
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
+  store i32 %7, i32 addrspace(1)* %8
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
+  %12 = load i32 addrspace(1)* %11, align 8
+  ret i32 %12
+}
+
+INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
+Successfully read CultureData.get_SPERCENT
+
+define %System.String addrspace(1)* @CultureData.get_SPERCENT(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
+Successfully read CultureData.get_SPERMILLE
+
+define %System.String addrspace(1)* @CultureData.get_SPERMILLE(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
+Successfully read CultureData.get_SNEGINFINITY
+
+define %System.String addrspace(1)* @CultureData.get_SNEGINFINITY(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
+Successfully read CultureData.get_SPOSINFINITY
+
+define %System.String addrspace(1)* @CultureData.get_SPOSINFINITY(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method CultureData::get_SNAN using LLILCJit
+Successfully read CultureData.get_SNAN
+
+define %System.String addrspace(1)* @CultureData.get_SNAN(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method StreamWriter::Write using LLILCJit
+Failed to read StreamWriter.Write[Tail call]
+INFO:  jitting method String::CopyTo using LLILCJit
+Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
+INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
+Successfully read WindowsConsoleStream.Write
+
+define void @WindowsConsoleStream.Write(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = load %"System.Byte[]" addrspace(1)** %arg1
+  %2 = load i32* %arg2
+  %3 = load i32* %arg3
+  %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
+  %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %7 = load i64 addrspace(1)* %6, align 8
+  %8 = load %"System.Byte[]" addrspace(1)** %arg1
+  %9 = load i32* %arg2
+  %10 = load i32* %arg3
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
+  store i32 %11, i32* %loc0
+  %12 = load i32* %loc0
+  %13 = icmp eq i32 %12, 0
+  br i1 %13, label %17, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = load i32* %loc0
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %entry
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
+Successfully read ConsoleStream.ValidateWrite
+
+define void @ConsoleStream.ValidateWrite(%System.IO.ConsoleStream addrspace(1)* %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32* %arg2
+  %7 = icmp slt i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load i32* %arg3
+  %10 = icmp sge i32 %9, 0
+  br i1 %10, label %22, label %11
+
+; <label>:11                                      ; preds = %5, %8
+  %12 = load i32* %arg2
+  %13 = icmp slt i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %18
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %18
+
+; <label>:18                                      ; preds = %14, %16
+  %19 = phi %System.String addrspace(1)* [ %15, %14 ], [ %17, %16 ]
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %21 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %21, %System.String addrspace(1)* %19, %System.String addrspace(1)* %20)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %21) #0
+  unreachable
+
+; <label>:22                                      ; preds = %8
+  %23 = load %"System.Byte[]" addrspace(1)** %arg1
+  %24 = getelementptr inbounds %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %25 = load i32 addrspace(1)* %24
+  %26 = zext i32 %25 to i64
+  %27 = trunc i64 %26 to i32
+  %28 = load i32* %arg2
+  %29 = sub i32 %27, %28
+  %30 = load i32* %arg3
+  %31 = icmp sge i32 %29, %30
+  br i1 %31, label %35, label %32
+
+; <label>:32                                      ; preds = %22
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %22
+  %36 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
+  %38 = load i8 addrspace(1)* %37, align 8
+  %39 = zext i8 %38 to i32
+  %40 = icmp ne i32 %39, 0
+  br i1 %40, label %43, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  ret void
+}
+
+INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
+Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method TextWriter::WriteLine using LLILCJit
+Failed to read TextWriter.WriteLine[Tail call]
+INFO:  jitting method StreamWriter::Write using LLILCJit
+Failed to read StreamWriter.Write[Tail call]
+

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
@@ -1,0 +1,5395 @@
+INFO:  jitting method AppDomain::SetupDomain using LLILCJit
+Successfully read AppDomain.SetupDomain
+
+define void @AppDomain.SetupDomain(%System.AppDomain addrspace(1)* %param0, i8 %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %"System.String[]" addrspace(1)*
+  %arg5 = alloca %"System.String[]" addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %"System.String[]" addrspace(1)* %param4, %"System.String[]" addrspace(1)** %arg4
+  store %"System.String[]" addrspace(1)* %param5, %"System.String[]" addrspace(1)** %arg5
+  store i8 0, i8* %loc1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.AppDomain addrspace(1)** %this
+  %4 = getelementptr inbounds %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %5 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
+  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %6, label %14, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
+  %9 = load %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
+  br i1 %NullCheck, label %11, label %ThrowNullRef
+
+; <label>:11                                      ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
+  %12 = load %System.AppDomain addrspace(1)** %this
+  %13 = load %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %11
+  br label %15
+
+; <label>:15                                      ; preds = %14
+  %16 = load i8* %loc1
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %22, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load %System.AppDomain addrspace(1)** %loc2
+  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
+  br label %22
+
+; <label>:22                                      ; preds = %15, %19
+  br label %23
+
+; <label>:23                                      ; preds = %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Monitor::Enter using LLILCJit
+Failed to read Monitor.Enter[Tail call]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Successfully read AppDomainSetup..ctor
+
+define void @AppDomainSetup..ctor(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.AppDomainSetup addrspace(1)** %this
+  %3 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %3
+  ret void
+}
+
+INFO:  jitting method Object::.ctor using LLILCJit
+Successfully read Object..ctor
+
+define void @Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::InternalSetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalSetApplicationTrust
+
+define void @AppDomainSetup.InternalSetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
+Successfully read AppDomain.SetupFusionStore
+
+define void @AppDomain.SetupFusionStore(%System.AppDomain addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.AppDomainSetup addrspace(1)*
+  %arg2 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
+  store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
+  %0 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %1
+  %5 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
+  br label %8
+
+; <label>:8                                       ; preds = %1, %7
+  %9 = load %System.AppDomain addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
+  %10 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %25, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %16 = icmp eq %System.AppDomainSetup addrspace(1)* %15, null
+  br i1 %16, label %30, label %17
+
+; <label>:17                                      ; preds = %14
+  %18 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+
+; <label>:19                                      ; preds = %17
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %System.AppDomainSetup addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %19
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %30, label %25
+
+; <label>:25                                      ; preds = %11, %22
+  %26 = load %System.AppDomain addrspace(1)** %this
+  %27 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+
+; <label>:28                                      ; preds = %25
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, i32)*)(%System.AppDomain addrspace(1)* %26, i32 %29)
+  br label %30
+
+; <label>:30                                      ; preds = %14, %22, %28
+  %31 = load %System.AppDomain addrspace(1)** %this
+  %32 = load %System.AppDomainSetup addrspace(1)** %arg1
+  %33 = getelementptr inbounds %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
+Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
+Successfully read AppDomainSetup.VerifyDir
+
+define %System.String addrspace(1)* @AppDomainSetup.VerifyDir(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %16, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = icmp ne i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %2
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
+  br label %16
+
+; <label>:8                                       ; preds = %2
+  %9 = load i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.AppDomainSetup addrspace(1)** %this
+  %14 = load %System.String addrspace(1)** %arg1
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
+  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
+  br label %16
+
+; <label>:16                                      ; preds = %entry, %7, %8, %12
+  %17 = load %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %17
+}
+
+INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
+Failed to read AppDomainSetup.SetupDefaults[storeElem]
+INFO:  jitting method String::LastIndexOfAny using LLILCJit
+Failed to read String.LastIndexOfAny[Tail call]
+INFO:  jitting method String::Substring using LLILCJit
+Failed to read String.Substring[Tail call]
+INFO:  jitting method String::InternalSubString using LLILCJit
+Successfully read String.InternalSubString
+
+define %System.String addrspace(1)* @String.InternalSubString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i16 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32* %arg2
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
+  store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
+  %2 = load %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String addrspace(1)* %2, i32 0, i32 2
+  %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
+  store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
+  %6 = load %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %3
+  %8 = getelementptr inbounds %System.String addrspace(1)* %6, i32 0, i32 2
+  %9 = bitcast [0 x i16] addrspace(1)* %8 to i16 addrspace(1)*
+  store i16 addrspace(1)* %9, i16 addrspace(1)** %loc2
+  %10 = load i16 addrspace(1)** %loc1
+  %11 = ptrtoint i16 addrspace(1)* %10 to i64
+  %12 = load i16 addrspace(1)** %loc2
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = load i32* %arg1
+  %15 = sext i32 %14 to i64
+  %16 = mul i64 %15, 2
+  %17 = add i64 %13, %16
+  %18 = load i32* %arg2
+  %19 = inttoptr i64 %11 to i16*
+  %20 = inttoptr i64 %17 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %19, i16* %20, i32 %18)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc2
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  %21 = load %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::wstrcpy using LLILCJit
+Failed to read String.wstrcpy[Tail call]
+INFO:  jitting method Buffer::Memmove using LLILCJit
+Failed to read Buffer.Memmove[Tail call]
+INFO:  jitting method String::Concat using LLILCJit
+Successfully read String.Concat
+
+define %System.String addrspace(1)* @String.Concat(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** %arg1
+  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %5)
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %4
+  %12 = load %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)** %arg1
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.String addrspace(1)** %arg0
+  ret %System.String addrspace(1)* %19
+
+; <label>:20                                      ; preds = %13
+  %21 = load %System.String addrspace(1)** %arg0
+  %22 = getelementptr inbounds %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32 addrspace(1)* %22
+  store i32 %23, i32* %loc0
+  %24 = load i32* %loc0
+  %25 = load %System.String addrspace(1)** %arg1
+  %26 = getelementptr inbounds %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32 addrspace(1)* %26
+  %28 = add i32 %24, %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
+  %30 = load %System.String addrspace(1)** %loc1
+  %31 = load %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %32 = load %System.String addrspace(1)** %loc1
+  %33 = load i32* %loc0
+  %34 = load %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
+  %35 = load %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %35
+}
+
+INFO:  jitting method String::IsNullOrEmpty using LLILCJit
+Successfully read String.IsNullOrEmpty
+
+define i8 @String.IsNullOrEmpty(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %9, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** %arg0
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = icmp eq i32 %5, 0
+  %7 = sext i1 %6 to i32
+  %8 = trunc i32 %7 to i8
+  ret i8 %8
+
+; <label>:9                                       ; preds = %entry
+  ret i8 1
+}
+
+INFO:  jitting method String::FillStringChecked using LLILCJit
+Successfully read String.FillStringChecked
+
+define void @String.FillStringChecked(%System.String addrspace(1)* %param0, i32 %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)** %arg2
+  %1 = getelementptr inbounds %System.String addrspace(1)* %0, i32 0, i32 1
+  %2 = load i32 addrspace(1)* %1
+  %3 = load %System.String addrspace(1)** %arg0
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = load i32* %arg1
+  %7 = sub i32 %5, %6
+  %8 = icmp sle i32 %2, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String addrspace(1)* %12, i32 0, i32 2
+  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
+  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
+  %16 = load %System.String addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String addrspace(1)* %16, i32 0, i32 2
+  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
+  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
+  %20 = load i16 addrspace(1)** %loc0
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = load i32* %arg1
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = add i64 %21, %24
+  %26 = load i16 addrspace(1)** %loc1
+  %27 = ptrtoint i16 addrspace(1)* %26 to i64
+  %28 = load %System.String addrspace(1)** %arg2
+  %29 = getelementptr inbounds %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32 addrspace(1)* %29
+  %31 = inttoptr i64 %25 to i16*
+  %32 = inttoptr i64 %27 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_LoaderOptimization using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimization
+
+define i32 @AppDomainSetup.get_LoaderOptimization(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %2 = load i32 addrspace(1)* %1, align 8
+  ret i32 %2
+}
+
+INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
+Failed to read AppDomain.PrepareDataForSetup[loadElem]
+INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
+Failed to read AppDomainSetup..ctor[storeElem]
+INFO:  jitting method List`1::.cctor using LLILCJit
+Failed to read List`1..cctor[callRuntimeHandleHelper]
+INFO:  jitting method String::Compare using LLILCJit
+Failed to read String.Compare[Tail call]
+INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
+Successfully read String.CompareOrdinalIgnoreCaseHelper
+
+define i32 @String.CompareOrdinalIgnoreCaseHelper(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i16 addrspace(1)*
+  %loc3 = alloca i16*
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca i32
+  %loc7 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = getelementptr inbounds %System.String addrspace(1)* %0, i32 0, i32 1
+  %2 = load i32 addrspace(1)* %1
+  %3 = load %System.String addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
+  store i32 %6, i32* %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.String addrspace(1)* %7, i32 0, i32 2
+  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
+  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
+  %11 = load %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %System.String addrspace(1)* %11, i32 0, i32 2
+  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
+  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
+  %15 = load i16 addrspace(1)** %loc1
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc3
+  %18 = load i16 addrspace(1)** %loc2
+  %19 = ptrtoint i16 addrspace(1)* %18 to i64
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc4
+  br label %60
+
+; <label>:21                                      ; preds = %60
+  %22 = load i16** %loc3
+  %23 = load i16* %22, align 8
+  %24 = zext i16 %23 to i32
+  store i32 %24, i32* %loc5
+  %25 = load i16** %loc4
+  %26 = load i16* %25, align 8
+  %27 = zext i16 %26 to i32
+  store i32 %27, i32* %loc6
+  %28 = load i32* %loc5
+  %29 = sub i32 %28, 97
+  %30 = icmp ugt i32 %29, 25
+  br i1 %30, label %34, label %31
+
+; <label>:31                                      ; preds = %21
+  %32 = load i32* %loc5
+  %33 = sub i32 %32, 32
+  store i32 %33, i32* %loc5
+  br label %34
+
+; <label>:34                                      ; preds = %21, %31
+  %35 = load i32* %loc6
+  %36 = sub i32 %35, 97
+  %37 = icmp ugt i32 %36, 25
+  br i1 %37, label %41, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load i32* %loc6
+  %40 = sub i32 %39, 32
+  store i32 %40, i32* %loc6
+  br label %41
+
+; <label>:41                                      ; preds = %34, %38
+  %42 = load i32* %loc5
+  %43 = load i32* %loc6
+  %44 = icmp eq i32 %42, %43
+  br i1 %44, label %49, label %45
+
+; <label>:45                                      ; preds = %41
+  %46 = load i32* %loc5
+  %47 = load i32* %loc6
+  %48 = sub i32 %46, %47
+  store i32 %48, i32* %loc7
+  br label %71
+
+; <label>:49                                      ; preds = %41
+  %50 = load i16** %loc3
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8* %51, i64 2
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc3
+  %54 = load i16** %loc4
+  %55 = bitcast i16* %54 to i8*
+  %56 = getelementptr inbounds i8* %55, i64 2
+  %57 = bitcast i8* %56 to i16*
+  store i16* %57, i16** %loc4
+  %58 = load i32* %loc0
+  %59 = sub i32 %58, 1
+  store i32 %59, i32* %loc0
+  br label %60
+
+; <label>:60                                      ; preds = %12, %49
+  %61 = load i32* %loc0
+  %62 = icmp ne i32 %61, 0
+  br i1 %62, label %21, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.String addrspace(1)** %arg0
+  %65 = getelementptr inbounds %System.String addrspace(1)* %64, i32 0, i32 1
+  %66 = load i32 addrspace(1)* %65
+  %67 = load %System.String addrspace(1)** %arg1
+  %68 = getelementptr inbounds %System.String addrspace(1)* %67, i32 0, i32 1
+  %69 = load i32 addrspace(1)* %68
+  %70 = sub i32 %66, %69
+  store i32 %70, i32* %loc7
+  br label %71
+
+; <label>:71                                      ; preds = %45, %63
+  %72 = load i32* %loc7
+  ret i32 %72
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Math::Min using LLILCJit
+Successfully read Math.Min
+
+define i32 @Math.Min(i32 %param0, i32 %param1) {
+entry:
+  %arg0 = alloca i32
+  %arg1 = alloca i32
+  store i32 %param0, i32* %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg0
+  %1 = load i32* %arg1
+  %2 = icmp sle i32 %0, %1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i32* %arg1
+  ret i32 %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32* %arg0
+  ret i32 %6
+}
+
+INFO:  jitting method List`1::Add using LLILCJit
+Failed to read List`1.Add[storeElem]
+INFO:  jitting method List`1::EnsureCapacity using LLILCJit
+Failed to read List`1.EnsureCapacity[Tail call]
+INFO:  jitting method List`1::set_Capacity using LLILCJit
+Failed to read List`1.set_Capacity[non-const derefAddress]
+INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
+Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
+INFO:  jitting method Dictionary`2::.ctor using LLILCJit
+Failed to read Dictionary`2..ctor[Call HasTypeArg]
+INFO:  jitting method EqualityComparer`1::get_Default using LLILCJit
+Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
+INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
+Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
+INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
+Failed to read RuntimeType.IsAssignableFrom[Tail call]
+INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
+Successfully read RuntimeType.get_UnderlyingSystemType
+
+define %System.Type addrspace(1)* @RuntimeType.get_UnderlyingSystemType(%System.RuntimeType addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  %0 = load %System.RuntimeType addrspace(1)** %this
+  %1 = bitcast %System.RuntimeType addrspace(1)* %0 to %System.Type addrspace(1)*
+  ret %System.Type addrspace(1)* %1
+}
+
+INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
+Failed to read GenericEqualityComparer`1..ctor[Tail call]
+INFO:  jitting method HashHelpers::.cctor using LLILCJit
+Failed to read HashHelpers..cctor[convertHandle]
+INFO:  jitting method String::UseRandomizedHashing using LLILCJit
+Failed to read String.UseRandomizedHashing[Tail call]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
+Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
+INFO:  jitting method Enumerator::MoveNext using LLILCJit
+Failed to read Enumerator.MoveNext[loadElem]
+INFO:  jitting method Enumerator::get_Current using LLILCJit
+Successfully read Enumerator.get_Current
+
+define %System.__Canon addrspace(1)* @Enumerator.get_Current(%"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.__Canon addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::.cctor using LLILCJit
+Successfully read StringComparer..cctor
+
+define void @StringComparer..cctor() {
+entry:
+  %0 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %1 = call %System.CultureAwareComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.CultureAwareComparer addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.CultureAwareComparer addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*, i8)*)(%System.CultureAwareComparer addrspace(1)* %1, %System.Globalization.CultureInfo addrspace(1)* %0, i8 0)
+  %2 = bitcast %System.CultureAwareComparer addrspace(1)* %1 to %System.StringComparer addrspace(1)*
+  %3 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %4 = getelementptr inbounds i8 addrspace(1)* %3, i64 56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.StringComparer addrspace(1)*)*)(i8 addrspace(1)* %4, %System.StringComparer addrspace(1)* %2)
+  %5 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %6 = call %System.CultureAwareComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.CultureAwareComparer addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.CultureAwareComparer addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*, i8)*)(%System.CultureAwareComparer addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)* %5, i8 1)
+  %7 = bitcast %System.CultureAwareComparer addrspace(1)* %6 to %System.StringComparer addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.StringComparer addrspace(1)*)*)(i8 addrspace(1)* %9, %System.StringComparer addrspace(1)* %7)
+  %10 = call %System.OrdinalComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OrdinalComparer addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OrdinalComparer addrspace(1)*, i8)*)(%System.OrdinalComparer addrspace(1)* %10, i8 0)
+  %11 = bitcast %System.OrdinalComparer addrspace(1)* %10 to %System.StringComparer addrspace(1)*
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.StringComparer addrspace(1)*)*)(i8 addrspace(1)* %13, %System.StringComparer addrspace(1)* %11)
+  %14 = call %System.OrdinalComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OrdinalComparer addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OrdinalComparer addrspace(1)*, i8)*)(%System.OrdinalComparer addrspace(1)* %14, i8 1)
+  %15 = bitcast %System.OrdinalComparer addrspace(1)* %14 to %System.StringComparer addrspace(1)*
+  %16 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %17 = getelementptr inbounds i8 addrspace(1)* %16, i64 80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.StringComparer addrspace(1)*)*)(i8 addrspace(1)* %17, %System.StringComparer addrspace(1)* %15)
+  ret void
+}
+
+INFO:  jitting method CultureInfo::get_InvariantCulture using LLILCJit
+Successfully read CultureInfo.get_InvariantCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_InvariantCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
+INFO:  jitting method CultureInfo::.cctor using LLILCJit
+Successfully read CultureInfo..cctor
+
+define void @CultureInfo..cctor() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  %3 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %4 = getelementptr inbounds i8 addrspace(1)* %3, i64 2201
+  %5 = addrspacecast i8 addrspace(1)* %4 to i8*
+  store i8 %2, i8* %5
+  ret void
+}
+
+INFO:  jitting method CultureInfo::Init using LLILCJit
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
+INFO:  jitting method CultureInfo::.ctor using LLILCJit
+Failed to read CultureInfo..ctor[Call intrinsic]
+INFO:  jitting method CultureData::GetCultureData using LLILCJit
+Failed to read CultureData.GetCultureData[Tail call]
+INFO:  jitting method CultureData::get_Invariant using LLILCJit
+Failed to read CultureData.get_Invariant[storeElem]
+INFO:  jitting method CalendarData::.cctor using LLILCJit
+Failed to read CalendarData..cctor[storeElem]
+INFO:  jitting method CalendarData::.ctor using LLILCJit
+Failed to read CalendarData..ctor[init class]
+INFO:  jitting method CultureData::get_CultureName using LLILCJit
+Successfully read CultureData.get_CultureName
+
+define %System.String addrspace(1)* @CultureData.get_CultureName(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
+  %3 = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** %loc0
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %16, label %10
+
+; <label>:10                                      ; preds = %4
+  %11 = load %System.String addrspace(1)** %loc0
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %4, %10
+  %17 = load %System.Globalization.CultureData addrspace(1)** %this
+  %18 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
+  %19 = load %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+; <label>:20                                      ; preds = %entry, %10
+  %21 = load %System.Globalization.CultureData addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+}
+
+INFO:  jitting method String::op_Equality using LLILCJit
+Failed to read String.op_Equality[Tail call]
+INFO:  jitting method String::Equals using LLILCJit
+Failed to read String.Equals[Tail call]
+INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
+Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
+Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
+INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
+Successfully read CultureInfo.GetCultureByName
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.GetCultureByName(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %6, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  br label %9
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %5, %3 ], [ %8, %6 ]
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  br label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+}
+
+INFO:  jitting method CultureInfo::.ctor using LLILCJit
+Failed to read CultureInfo..ctor[Tail call]
+INFO:  jitting method CultureData::AnsiToLower using LLILCJit
+Failed to read CultureData.AnsiToLower[Tail call]
+INFO:  jitting method StringBuilder::.ctor using LLILCJit
+Failed to read StringBuilder..ctor[storeElem]
+INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
+Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+INFO:  jitting method StringBuilder::Append using LLILCJit
+Failed to read StringBuilder.Append[storeElem]
+INFO:  jitting method StringBuilder::ToString using LLILCJit
+Failed to read StringBuilder.ToString[loadElemA]
+INFO:  jitting method CultureData::CreateCultureData using LLILCJit
+Successfully read CultureData.CreateCultureData
+
+define %System.Globalization.CultureData addrspace(1)* @CultureData.CreateCultureData(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %loc0 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  store %System.Globalization.CultureData addrspace(1)* %0, %System.Globalization.CultureData addrspace(1)** %loc0
+  %1 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %2 = load i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  %9 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %entry
+  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret %System.Globalization.CultureData addrspace(1)* null
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::.ctor using LLILCJit
+Failed to read CultureData..ctor[Tail call]
+INFO:  jitting method CultureData::InitCultureData using LLILCJit
+Successfully read CultureData.InitCultureData
+
+define i8 @CultureData.InitCultureData(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i8 0
+
+; <label>:5                                       ; preds = %entry
+  ret i8 1
+}
+
+INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
+Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
+INFO:  jitting method Dictionary`2::Insert using LLILCJit
+Failed to read Dictionary`2.Insert[non-const derefAddress]
+INFO:  jitting method Dictionary`2::Initialize using LLILCJit
+Failed to read Dictionary`2.Initialize[non-const derefAddress]
+INFO:  jitting method HashHelpers::GetPrime using LLILCJit
+Failed to read HashHelpers.GetPrime[loadElem]
+INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
+Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+INFO:  jitting method String::GetHashCode using LLILCJit
+Failed to read String.GetHashCode[Tail call]
+INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
+Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
+Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
+INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
+INFO:  jitting method CultureInfo::get_Name using LLILCJit
+Successfully read CultureInfo.get_Name
+
+define %System.String addrspace(1)* @CultureInfo.get_Name(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %20, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
+  %14 = load %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %15, label %20, label %16
+
+; <label>:16                                      ; preds = %9
+  %17 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %18 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  br label %20
+
+; <label>:20                                      ; preds = %entry, %9, %16
+  %21 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  ret %System.String addrspace(1)* %23
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SNAME using LLILCJit
+Successfully read CultureData.get_SNAME
+
+define %System.String addrspace(1)* @CultureData.get_SNAME(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load %System.Globalization.CultureData addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
+  %11 = load %System.String addrspace(1)* addrspace(1)* %10, align 8
+  ret %System.String addrspace(1)* %11
+}
+
+INFO:  jitting method String::EqualsHelper using LLILCJit
+Successfully read String.EqualsHelper
+
+define i8 @String.EqualsHelper(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i16 addrspace(1)*
+  %loc3 = alloca i16*
+  %loc4 = alloca i16*
+  %loc5 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = getelementptr inbounds %System.String addrspace(1)* %0, i32 0, i32 1
+  %2 = load i32 addrspace(1)* %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 2
+  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
+  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
+  %7 = load %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.String addrspace(1)* %7, i32 0, i32 2
+  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
+  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
+  %11 = load i16 addrspace(1)** %loc1
+  %12 = ptrtoint i16 addrspace(1)* %11 to i64
+  %13 = inttoptr i64 %12 to i16*
+  store i16* %13, i16** %loc3
+  %14 = load i16 addrspace(1)** %loc2
+  %15 = ptrtoint i16 addrspace(1)* %14 to i64
+  %16 = inttoptr i64 %15 to i16*
+  store i16* %16, i16** %loc4
+  br label %63
+
+; <label>:17                                      ; preds = %63
+  %18 = load i16** %loc3
+  %19 = bitcast i16* %18 to i64*
+  %20 = load i64* %19, align 8
+  %21 = load i16** %loc4
+  %22 = bitcast i16* %21 to i64*
+  %23 = load i64* %22, align 8
+  %24 = icmp eq i64 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  store i8 0, i8* %loc5
+  br label %96
+
+; <label>:26                                      ; preds = %17
+  %27 = load i16** %loc3
+  %28 = bitcast i16* %27 to i8*
+  %29 = getelementptr inbounds i8* %28, i64 8
+  %30 = bitcast i8* %29 to i64*
+  %31 = load i64* %30, align 8
+  %32 = load i16** %loc4
+  %33 = bitcast i16* %32 to i8*
+  %34 = getelementptr inbounds i8* %33, i64 8
+  %35 = bitcast i8* %34 to i64*
+  %36 = load i64* %35, align 8
+  %37 = icmp eq i64 %31, %36
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %26
+  store i8 0, i8* %loc5
+  br label %96
+
+; <label>:39                                      ; preds = %26
+  %40 = load i16** %loc3
+  %41 = bitcast i16* %40 to i8*
+  %42 = getelementptr inbounds i8* %41, i64 16
+  %43 = bitcast i8* %42 to i64*
+  %44 = load i64* %43, align 8
+  %45 = load i16** %loc4
+  %46 = bitcast i16* %45 to i8*
+  %47 = getelementptr inbounds i8* %46, i64 16
+  %48 = bitcast i8* %47 to i64*
+  %49 = load i64* %48, align 8
+  %50 = icmp eq i64 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %39
+  store i8 0, i8* %loc5
+  br label %96
+
+; <label>:52                                      ; preds = %39
+  %53 = load i16** %loc3
+  %54 = bitcast i16* %53 to i8*
+  %55 = getelementptr inbounds i8* %54, i64 24
+  %56 = bitcast i8* %55 to i16*
+  store i16* %56, i16** %loc3
+  %57 = load i16** %loc4
+  %58 = bitcast i16* %57 to i8*
+  %59 = getelementptr inbounds i8* %58, i64 24
+  %60 = bitcast i8* %59 to i16*
+  store i16* %60, i16** %loc4
+  %61 = load i32* %loc0
+  %62 = sub i32 %61, 12
+  store i32 %62, i32* %loc0
+  br label %63
+
+; <label>:63                                      ; preds = %8, %52
+  %64 = load i32* %loc0
+  %65 = icmp sge i32 %64, 12
+  br i1 %65, label %17, label %66
+
+; <label>:66                                      ; preds = %63
+  br label %86
+
+; <label>:67                                      ; preds = %86
+  %68 = load i16** %loc3
+  %69 = bitcast i16* %68 to i32*
+  %70 = load i32* %69, align 8
+  %71 = load i16** %loc4
+  %72 = bitcast i16* %71 to i32*
+  %73 = load i32* %72, align 8
+  %74 = icmp ne i32 %70, %73
+  br i1 %74, label %89, label %75
+
+; <label>:75                                      ; preds = %67
+  %76 = load i16** %loc3
+  %77 = bitcast i16* %76 to i8*
+  %78 = getelementptr inbounds i8* %77, i64 4
+  %79 = bitcast i8* %78 to i16*
+  store i16* %79, i16** %loc3
+  %80 = load i16** %loc4
+  %81 = bitcast i16* %80 to i8*
+  %82 = getelementptr inbounds i8* %81, i64 4
+  %83 = bitcast i8* %82 to i16*
+  store i16* %83, i16** %loc4
+  %84 = load i32* %loc0
+  %85 = sub i32 %84, 2
+  store i32 %85, i32* %loc0
+  br label %86
+
+; <label>:86                                      ; preds = %66, %75
+  %87 = load i32* %loc0
+  %88 = icmp sgt i32 %87, 0
+  br i1 %88, label %67, label %89
+
+; <label>:89                                      ; preds = %67, %86
+  %90 = load i32* %loc0
+  %91 = icmp sgt i32 %90, 0
+  %92 = sext i1 %91 to i32
+  %93 = icmp eq i32 %92, 0
+  %94 = sext i1 %93 to i32
+  %95 = trunc i32 %94 to i8
+  store i8 %95, i8* %loc5
+  br label %96
+
+; <label>:96                                      ; preds = %25, %38, %51, %89
+  %97 = load i8* %loc5
+  %98 = zext i8 %97 to i32
+  %99 = trunc i32 %98 to i8
+  ret i8 %99
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureAwareComparer::.ctor using LLILCJit
+Successfully read CultureAwareComparer..ctor
+
+define void @CultureAwareComparer..ctor(%System.CultureAwareComparer addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.CultureAwareComparer addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg2 = alloca i8
+  store %System.CultureAwareComparer addrspace(1)* %param0, %System.CultureAwareComparer addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.CultureAwareComparer addrspace(1)** %this
+  %1 = bitcast %System.CultureAwareComparer addrspace(1)* %0 to %System.StringComparer addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
+  %2 = load %System.CultureAwareComparer addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
+  %5 = load i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %14 = getelementptr inbounds %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
+  %15 = load %System.CultureAwareComparer addrspace(1)** %this
+  %16 = load i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
+  store i8 %18, i8 addrspace(1)* %19
+  ret void
+}
+
+INFO:  jitting method StringComparer::.ctor using LLILCJit
+Failed to read StringComparer..ctor[Tail call]
+INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
+Successfully read CultureInfo.get_CompareInfo
+
+define %System.Globalization.CompareInfo addrspace(1)* @CultureInfo.get_CompareInfo(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %2 = load %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %3, label %38, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
+  %7 = zext i8 %6 to i32
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %12, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
+  br label %27
+
+; <label>:12                                      ; preds = %4
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64 addrspace(1)* %17
+  %19 = add i64 %18, 72
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64* %20
+  %22 = add i64 %21, 16
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64* %23
+  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
+  br label %27
+
+; <label>:27                                      ; preds = %9, %12
+  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %30 = zext i8 %29 to i32
+  %31 = icmp eq i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %27
+  %33 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %34 = load %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %35 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
+  br label %38
+
+; <label>:36                                      ; preds = %27
+  %37 = load %System.Globalization.CompareInfo addrspace(1)** %loc0
+  ret %System.Globalization.CompareInfo addrspace(1)* %37
+
+; <label>:38                                      ; preds = %entry, %32
+  %39 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %40 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
+  %41 = load %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %41
+}
+
+INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
+Failed to read CultureInfo.get_UseUserOverride[Tail call]
+INFO:  jitting method CompareInfo::.ctor using LLILCJit
+Successfully read CompareInfo..ctor
+
+define void @CompareInfo..ctor(%System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CompareInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca i64
+  store %System.Globalization.CompareInfo addrspace(1)* %param0, %System.Globalization.CompareInfo addrspace(1)** %this
+  store %System.Globalization.CultureInfo addrspace(1)* %param1, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.CompareInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %5 = load %System.String addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
+  %7 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %13 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
+  store i64 %17, i64 addrspace(1)* %18
+  %19 = load %System.Globalization.CompareInfo addrspace(1)** %this
+  %20 = load i64* %loc0
+  %21 = getelementptr inbounds %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
+  store i64 %20, i64 addrspace(1)* %21
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureInfo::get_SortName using LLILCJit
+Successfully read CultureInfo.get_SortName
+
+define %System.String addrspace(1)* @CultureInfo.get_SortName(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %12, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %4
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  br label %12
+
+; <label>:12                                      ; preds = %entry, %9
+  %13 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
+  %15 = load %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_SCOMPAREINFO using LLILCJit
+Successfully read CultureData.get_SCOMPAREINFO
+
+define %System.String addrspace(1)* @CultureData.get_SCOMPAREINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
+Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
+Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
+
+define i8 @CompatibilitySwitches.get_IsCompatibilityBehaviorDefined() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1986
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
+INFO:  jitting method OrdinalComparer::.ctor using LLILCJit
+Successfully read OrdinalComparer..ctor
+
+define void @OrdinalComparer..ctor(%System.OrdinalComparer addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca i8
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.OrdinalComparer addrspace(1)** %this
+  %1 = bitcast %System.OrdinalComparer addrspace(1)* %0 to %System.StringComparer addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
+  %2 = load %System.OrdinalComparer addrspace(1)** %this
+  %3 = load i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %6
+  ret void
+}
+
+INFO:  jitting method OrdinalComparer::Equals using LLILCJit
+Failed to read OrdinalComparer.Equals[Tail call]
+INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
+Successfully read Enumerator.MoveNextRare
+
+define i8 @Enumerator.MoveNextRare(%"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
+  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
+  %7 = load i32 addrspace(1)* %6, align 8
+  %8 = icmp eq i32 %2, %7
+  br i1 %8, label %10, label %9
+
+; <label>:9                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %9
+  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
+  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
+  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
+  %16 = load i32 addrspace(1)* %15, align 8
+  %17 = add i32 %16, 1
+  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
+  store i32 %17, i32 addrspace(1)* %18
+  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
+
+; <label>:20                                      ; preds = %10
+  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Enumerator::Dispose using LLILCJit
+Successfully read Enumerator.Dispose
+
+define void @Enumerator.Dispose(%"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  ret void
+}
+
+INFO:  jitting method AppDomain::Setup using LLILCJit
+Failed to read AppDomain.Setup[loadElem]
+INFO:  jitting method Thread::GetDomain using LLILCJit
+Successfully read Thread.GetDomain
+
+define %System.AppDomain addrspace(1)* @Thread.GetDomain() {
+entry:
+  %loc0 = alloca %System.AppDomain addrspace(1)*
+  %0 = call %System.AppDomain addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomain addrspace(1)* ()*)()
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc0
+  %1 = load %System.AppDomain addrspace(1)** %loc0
+  %2 = icmp ne %System.AppDomain addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.AppDomain addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomain addrspace(1)* ()*)()
+  store %System.AppDomain addrspace(1)* %4, %System.AppDomain addrspace(1)** %loc0
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %3
+  %6 = load %System.AppDomain addrspace(1)** %loc0
+  ret %System.AppDomain addrspace(1)* %6
+}
+
+INFO:  jitting method AppDomainSetup::GetConfigurationBytes using LLILCJit
+Successfully read AppDomainSetup.GetConfigurationBytes
+
+define %"System.Byte[]" addrspace(1)* @AppDomainSetup.GetConfigurationBytes(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %2 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %"System.Byte[]" addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
+  %8 = load %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %5
+  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
+  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
+  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
+  ret %"System.Byte[]" addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method KeyCollection::.ctor using LLILCJit
+Successfully read KeyCollection..ctor
+
+define void @KeyCollection..ctor(%"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param1, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
+  %3 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 1)
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
+  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  ret void
+}
+
+INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
+Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
+INFO:  jitting method Enumerator::MoveNext using LLILCJit
+Failed to read Enumerator.MoveNext[loadElemA]
+INFO:  jitting method Enumerator::get_Current using LLILCJit
+Successfully read Enumerator.get_Current
+
+define %System.__Canon addrspace(1)* @Enumerator.get_Current(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.__Canon addrspace(1)* %2
+}
+
+INFO:  jitting method Enumerator::Dispose using LLILCJit
+Successfully read Enumerator.Dispose
+
+define void @Enumerator.Dispose(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  ret void
+}
+
+INFO:  jitting method AppDomainSetup::get_TargetFrameworkName using LLILCJit
+Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
+INFO:  jitting method Path::.cctor using LLILCJit
+Failed to read Path..cctor[convertHandle]
+INFO:  jitting method String::SplitInternal using LLILCJit
+Failed to read String.SplitInternal[Tail call]
+INFO:  jitting method String::MakeSeparatorList using LLILCJit
+Failed to read String.MakeSeparatorList[loadElemA]
+INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
+Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+INFO:  jitting method Path::IsRelative using LLILCJit
+Successfully read Path.IsRelative
+
+define i8 @Path.IsRelative(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = getelementptr inbounds %System.String addrspace(1)* %0, i32 0, i32 1
+  %2 = load i32 addrspace(1)* %1
+  %3 = icmp slt i32 %2, 3
+  br i1 %3, label %50, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** %arg0
+  %6 = getelementptr inbounds %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
+  %7 = load i16 addrspace(1)* %6
+  %8 = zext i16 %7 to i32
+  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %10 = getelementptr inbounds i8 addrspace(1)* %9, i64 2380
+  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
+  %12 = load i16* %11
+  %13 = zext i16 %12 to i32
+  %14 = icmp ne i32 %8, %13
+  br i1 %14, label %50, label %15
+
+; <label>:15                                      ; preds = %4
+  %16 = load %System.String addrspace(1)** %arg0
+  %17 = getelementptr inbounds %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
+  %18 = load i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 2376
+  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
+  %23 = load i16* %22
+  %24 = zext i16 %23 to i32
+  %25 = icmp ne i32 %19, %24
+  br i1 %25, label %50, label %26
+
+; <label>:26                                      ; preds = %15
+  %27 = load %System.String addrspace(1)** %arg0
+  %28 = getelementptr inbounds %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
+  %29 = load i16 addrspace(1)* %28
+  %30 = zext i16 %29 to i32
+  %31 = icmp slt i32 %30, 97
+  br i1 %31, label %38, label %32
+
+; <label>:32                                      ; preds = %26
+  %33 = load %System.String addrspace(1)** %arg0
+  %34 = getelementptr inbounds %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
+  %35 = load i16 addrspace(1)* %34
+  %36 = zext i16 %35 to i32
+  %37 = icmp sle i32 %36, 122
+  br i1 %37, label %67, label %38
+
+; <label>:38                                      ; preds = %26, %32
+  %39 = load %System.String addrspace(1)** %arg0
+  %40 = getelementptr inbounds %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
+  %41 = load i16 addrspace(1)* %40
+  %42 = zext i16 %41 to i32
+  %43 = icmp slt i32 %42, 65
+  br i1 %43, label %50, label %44
+
+; <label>:44                                      ; preds = %38
+  %45 = load %System.String addrspace(1)** %arg0
+  %46 = getelementptr inbounds %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+  %47 = load i16 addrspace(1)* %46
+  %48 = zext i16 %47 to i32
+  %49 = icmp sle i32 %48, 90
+  br i1 %49, label %67, label %50
+
+; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+  %51 = load %System.String addrspace(1)** %arg0
+  %52 = getelementptr inbounds %System.String addrspace(1)* %51, i32 0, i32 1
+  %53 = load i32 addrspace(1)* %52
+  %54 = icmp slt i32 %53, 2
+  br i1 %54, label %68, label %55
+
+; <label>:55                                      ; preds = %50
+  %56 = load %System.String addrspace(1)** %arg0
+  %57 = getelementptr inbounds %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
+  %58 = load i16 addrspace(1)* %57
+  %59 = zext i16 %58 to i32
+  %60 = icmp ne i32 %59, 92
+  br i1 %60, label %68, label %61
+
+; <label>:61                                      ; preds = %55
+  %62 = load %System.String addrspace(1)** %arg0
+  %63 = getelementptr inbounds %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
+  %64 = load i16 addrspace(1)* %63
+  %65 = zext i16 %64 to i32
+  %66 = icmp ne i32 %65, 92
+  br i1 %66, label %68, label %67
+
+; <label>:67                                      ; preds = %32, %44, %61
+  ret i8 0
+
+; <label>:68                                      ; preds = %50, %55, %61
+  ret i8 1
+}
+
+INFO:  jitting method Path::NormalizePath using LLILCJit
+Failed to read Path.NormalizePath[entryLabel]
+INFO:  jitting method String::TrimHelper using LLILCJit
+Failed to read String.TrimHelper[loadElem]
+INFO:  jitting method String::CreateTrimmedString using LLILCJit
+Failed to read String.CreateTrimmedString[Tail call]
+INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
+Successfully read Path.CheckInvalidPathChars
+
+define void @Path.CheckInvalidPathChars(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** %arg0
+  %7 = load i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = trunc i32 %8 to i8
+  %10 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %6, i8 %9)
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %5
+  ret void
+}
+
+INFO:  jitting method Path::HasIllegalCharacters using LLILCJit
+Successfully read Path.HasIllegalCharacters
+
+define i8 @Path.HasIllegalCharacters(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load i8* %arg1
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)** %arg0
+  %5 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %6 = getelementptr inbounds i8 addrspace(1)* %5, i64 2872
+  %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
+  %8 = load %"System.Char[]" addrspace(1)** %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %3
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
+  %11 = icmp slt i32 %10, 0
+  %12 = sext i1 %11 to i32
+  %13 = icmp eq i32 %12, 0
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  ret i8 %15
+
+; <label>:16                                      ; preds = %entry
+  %17 = load %System.String addrspace(1)** %arg0
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 2864
+  %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
+  %21 = load %"System.Char[]" addrspace(1)** %20
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+
+; <label>:22                                      ; preds = %16
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
+  %24 = icmp slt i32 %23, 0
+  %25 = sext i1 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  %27 = sext i1 %26 to i32
+  %28 = trunc i32 %27 to i8
+  ret i8 %28
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method String::IndexOfAny using LLILCJit
+Failed to read String.IndexOfAny[Tail call]
+INFO:  jitting method PathHelper::Append using LLILCJit
+Successfully read PathHelper.Append
+
+define void @PathHelper.Append(%System.IO.PathHelper addrspace(1)* %param0, i16 %param1) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca i16
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store i16 %param1, i16* %arg1
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = add i32 %1, 1
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = icmp slt i32 %2, %5
+  br i1 %6, label %11, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+  unreachable
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.IO.PathHelper addrspace(1)** %this
+  %13 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
+  %14 = load i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %35, label %17
+
+; <label>:17                                      ; preds = %11
+  %18 = load %System.IO.PathHelper addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
+  %20 = load i16* addrspace(1)* %19, align 8
+  %21 = load %System.IO.PathHelper addrspace(1)** %this
+  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %20 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = load i16* %arg1
+  %28 = zext i16 %27 to i32
+  %29 = bitcast i8* %26 to i32*
+  store i32 %28, i32* %29, align 8
+  %30 = load %System.IO.PathHelper addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  %32 = load i32 addrspace(1)* %31, align 8
+  %33 = add i32 %32, 1
+  %34 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
+  store i32 %33, i32 addrspace(1)* %34
+  ret void
+
+; <label>:35                                      ; preds = %11
+  %36 = load %System.IO.PathHelper addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
+  %38 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
+  %39 = load i16* %arg1
+  %40 = zext i16 %39 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
+  br i1 %NullCheck, label %41, label %ThrowNullRef
+
+; <label>:41                                      ; preds = %35
+  %42 = trunc i32 %40 to i16
+  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+  ret void
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PathHelper::get_Length using LLILCJit
+Failed to read PathHelper.get_Length[Tail call]
+INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
+Failed to read PathHelper.OrdinalStartsWith[Tail call]
+INFO:  jitting method PathHelper::NullTerminate using LLILCJit
+Successfully read PathHelper.NullTerminate
+
+define void @PathHelper.NullTerminate(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %2 = load i16* addrspace(1)* %1, align 8
+  %3 = load %System.IO.PathHelper addrspace(1)** %this
+  %4 = getelementptr inbounds %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = sext i32 %5 to i64
+  %7 = mul i64 %6, 2
+  %8 = bitcast i16* %2 to i8*
+  %9 = getelementptr inbounds i8* %8, i64 %7
+  %10 = bitcast i8* %9 to i32*
+  store i32 0, i32* %10, align 8
+  ret void
+}
+
+INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
+Failed to read PathHelper.GetFullPathName[entryLabel]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method PathHelper::ToString using LLILCJit
+Failed to read PathHelper.ToString[Tail call]
+INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
+Successfully read String.CtorCharPtrStartLength
+
+define %System.String addrspace(1)* @String.CtorCharPtrStartLength(%System.String addrspace(1)* %param0, i16* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16*
+  %loc1 = alloca %System.String addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %System.String addrspace(1)*
+  %loc4 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32* %arg3
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i16** %arg1
+  %17 = load i32* %arg2
+  %18 = sext i32 %17 to i64
+  %19 = mul i64 %18, 2
+  %20 = bitcast i16* %16 to i8*
+  %21 = getelementptr inbounds i8* %20, i64 %19
+  %22 = bitcast i8* %21 to i16*
+  store i16* %22, i16** %loc0
+  %23 = load i16** %loc0
+  %24 = load i16** %arg1
+  %25 = icmp uge i16* %23, %24
+  br i1 %25, label %31, label %26
+
+; <label>:26                                      ; preds = %15
+  %27 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %28 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %28)
+  %30 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %30, %System.String addrspace(1)* %27, %System.String addrspace(1)* %29)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %30) #0
+  unreachable
+
+; <label>:31                                      ; preds = %15
+  %32 = load i32* %arg3
+  %33 = icmp ne i32 %32, 0
+  br i1 %33, label %36, label %34
+
+; <label>:34                                      ; preds = %31
+  %35 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %35
+
+; <label>:36                                      ; preds = %31
+  %37 = load i32* %arg3
+  %38 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %37)
+  store %System.String addrspace(1)* %38, %System.String addrspace(1)** %loc1
+  %39 = load %System.String addrspace(1)** %loc1
+  store %System.String addrspace(1)* %39, %System.String addrspace(1)** %loc4
+  %40 = load %System.String addrspace(1)** %loc4
+  %41 = ptrtoint %System.String addrspace(1)* %40 to i64
+  %42 = icmp eq i64 %41, 0
+  br i1 %42, label %47, label %43
+
+; <label>:43                                      ; preds = %36
+  %44 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %45 = sext i32 %44 to i64
+  %46 = add i64 %41, %45
+  br label %47
+
+; <label>:47                                      ; preds = %36, %43
+  %48 = phi i64 [ %41, %36 ], [ %46, %43 ]
+  %49 = inttoptr i64 %48 to i16*
+  store i16* %49, i16** %loc2
+  %50 = load i16** %loc2
+  %51 = load i16** %loc0
+  %52 = load i32* %arg3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %50, i16* %51, i32 %52)
+  br label %53
+
+; <label>:53                                      ; preds = %47
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc4
+  br label %54
+
+; <label>:54                                      ; preds = %53
+  %55 = load %System.String addrspace(1)** %loc1
+  store %System.String addrspace(1)* %55, %System.String addrspace(1)** %loc3
+  br label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = load %System.String addrspace(1)** %loc3
+  ret %System.String addrspace(1)* %57
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
+INFO:  jitting method String::Equals using LLILCJit
+Failed to read String.Equals[Tail call]
+INFO:  jitting method StringBuilder::Append using LLILCJit
+Failed to read StringBuilder.Append[storeElem]
+INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
+Successfully read StringBuilder.AppendHelper
+
+define void @StringBuilder.AppendHelper(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca %System.String addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc1
+  %1 = load %System.String addrspace(1)** %loc1
+  %2 = ptrtoint %System.String addrspace(1)* %1 to i64
+  %3 = icmp eq i64 %2, 0
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %6 = sext i32 %5 to i64
+  %7 = add i64 %2, %6
+  br label %8
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = phi i64 [ %2, %entry ], [ %7, %4 ]
+  %10 = inttoptr i64 %9 to i16*
+  store i16* %10, i16** %loc0
+  %11 = load %System.Text.StringBuilder addrspace(1)** %this
+  %12 = load i16** %loc0
+  %13 = load %System.String addrspace(1)** %arg1
+  %14 = getelementptr inbounds %System.String addrspace(1)* %13, i32 0, i32 1
+  %15 = load i32 addrspace(1)* %14
+  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
+  ret void
+}
+
+INFO:  jitting method StringBuilder::Append using LLILCJit
+Successfully read StringBuilder.Append
+
+define %System.Text.StringBuilder addrspace(1)* @StringBuilder.Append(%System.Text.StringBuilder addrspace(1)* %param0, i16* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32* %arg2
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg2
+  %9 = load %System.Text.StringBuilder addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %11 = load i32 addrspace(1)* %10, align 8
+  %12 = add i32 %8, %11
+  store i32 %12, i32* %loc0
+  %13 = load i32* %loc0
+  %14 = load %System.Text.StringBuilder addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
+  %16 = load %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = getelementptr inbounds %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
+  %18 = load i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %13, %20
+  br i1 %21, label %34, label %22
+
+; <label>:22                                      ; preds = %7
+  %23 = load i16** %arg1
+  %24 = load %System.Text.StringBuilder addrspace(1)** %this
+  %25 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
+  %26 = load %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+  %27 = load %System.Text.StringBuilder addrspace(1)** %this
+  %28 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
+  %29 = load i32 addrspace(1)* %28, align 8
+  %30 = load i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %31 = load %System.Text.StringBuilder addrspace(1)** %this
+  %32 = load i32* %loc0
+  %33 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
+  store i32 %32, i32 addrspace(1)* %33
+  br label %86
+
+; <label>:34                                      ; preds = %7
+  %35 = load %System.Text.StringBuilder addrspace(1)** %this
+  %36 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
+  %37 = load %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
+  %38 = getelementptr inbounds %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %39 = load i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load %System.Text.StringBuilder addrspace(1)** %this
+  %43 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
+  %44 = load i32 addrspace(1)* %43, align 8
+  %45 = sub i32 %41, %44
+  store i32 %45, i32* %loc1
+  %46 = load i32* %loc1
+  %47 = icmp sle i32 %46, 0
+  br i1 %47, label %66, label %48
+
+; <label>:48                                      ; preds = %34
+  %49 = load i16** %arg1
+  %50 = load %System.Text.StringBuilder addrspace(1)** %this
+  %51 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
+  %52 = load %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
+  %53 = load %System.Text.StringBuilder addrspace(1)** %this
+  %54 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
+  %55 = load i32 addrspace(1)* %54, align 8
+  %56 = load i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
+  %57 = load %System.Text.StringBuilder addrspace(1)** %this
+  %58 = load %System.Text.StringBuilder addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
+  %60 = load %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
+  %61 = getelementptr inbounds %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
+  %62 = load i32 addrspace(1)* %61
+  %63 = zext i32 %62 to i64
+  %64 = trunc i64 %63 to i32
+  %65 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  store i32 %64, i32 addrspace(1)* %65
+  br label %66
+
+; <label>:66                                      ; preds = %34, %48
+  %67 = load i32* %arg2
+  %68 = load i32* %loc1
+  %69 = sub i32 %67, %68
+  store i32 %69, i32* %loc2
+  %70 = load %System.Text.StringBuilder addrspace(1)** %this
+  %71 = load i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
+  %72 = load i16** %arg1
+  %73 = load i32* %loc1
+  %74 = sext i32 %73 to i64
+  %75 = mul i64 %74, 2
+  %76 = bitcast i16* %72 to i8*
+  %77 = getelementptr inbounds i8* %76, i64 %75
+  %78 = load %System.Text.StringBuilder addrspace(1)** %this
+  %79 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
+  %80 = load %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
+  %81 = load i32* %loc2
+  %82 = bitcast i8* %77 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
+  %83 = load %System.Text.StringBuilder addrspace(1)** %this
+  %84 = load i32* %loc2
+  %85 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
+  store i32 %84, i32 addrspace(1)* %85
+  br label %86
+
+; <label>:86                                      ; preds = %22, %66
+  %87 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %87
+}
+
+INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
+Successfully read StringBuilder.ExpandByABlock
+
+define void @StringBuilder.ExpandByABlock(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg1
+  %1 = load %System.Text.StringBuilder addrspace(1)** %this
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
+  %3 = add i32 %0, %2
+  %4 = load %System.Text.StringBuilder addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %6 = load i32 addrspace(1)* %5, align 8
+  %7 = icmp sle i32 %3, %6
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %entry
+  %14 = load i32* %arg1
+  %15 = load %System.Text.StringBuilder addrspace(1)** %this
+  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
+  store i32 %18, i32* %loc0
+  %19 = load %System.Text.StringBuilder addrspace(1)** %this
+  %20 = load %System.Text.StringBuilder addrspace(1)** %this
+  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
+  %22 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %23 = load %System.Text.StringBuilder addrspace(1)** %this
+  %24 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %25 = load i32 addrspace(1)* %24, align 8
+  %26 = load %System.Text.StringBuilder addrspace(1)** %this
+  %27 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
+  %28 = load i32 addrspace(1)* %27, align 8
+  %29 = add i32 %25, %28
+  %30 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  store i32 %29, i32 addrspace(1)* %30
+  %31 = load %System.Text.StringBuilder addrspace(1)** %this
+  %32 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %32
+  %33 = load %System.Text.StringBuilder addrspace(1)** %this
+  %34 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
+  %35 = load i32 addrspace(1)* %34, align 8
+  %36 = load i32* %loc0
+  %37 = add i32 %35, %36
+  %38 = load i32* %loc0
+  %39 = icmp sge i32 %37, %38
+  br i1 %39, label %44, label %40
+
+; <label>:40                                      ; preds = %13
+  %41 = load %System.Text.StringBuilder addrspace(1)** %this
+  %42 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
+  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+  unreachable
+
+; <label>:44                                      ; preds = %13
+  %45 = load %System.Text.StringBuilder addrspace(1)** %this
+  %46 = load i32* %loc0
+  %47 = sext i32 %46 to i64
+  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
+  %49 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+  ret void
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = load %System.Text.StringBuilder addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = add i32 %2, %5
+  ret i32 %6
+}
+
+INFO:  jitting method Math::Max using LLILCJit
+Successfully read Math.Max
+
+define i32 @Math.Max(i32 %param0, i32 %param1) {
+entry:
+  %arg0 = alloca i32
+  %arg1 = alloca i32
+  store i32 %param0, i32* %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg0
+  %1 = load i32* %arg1
+  %2 = icmp sge i32 %0, %1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i32* %arg1
+  ret i32 %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32* %arg0
+  ret i32 %6
+}
+
+INFO:  jitting method StringBuilder::.ctor using LLILCJit
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %param1, %System.Text.StringBuilder addrspace(1)** %arg1
+  %0 = load %System.Text.StringBuilder addrspace(1)** %this
+  %1 = bitcast %System.Text.StringBuilder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Text.StringBuilder addrspace(1)** %this
+  %3 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %5, i32 addrspace(1)* %6
+  %7 = load %System.Text.StringBuilder addrspace(1)** %this
+  %8 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %9 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32 addrspace(1)* %9, align 8
+  %11 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
+  store i32 %10, i32 addrspace(1)* %11
+  %12 = load %System.Text.StringBuilder addrspace(1)** %this
+  %13 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %14 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
+  %15 = load %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
+  %16 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
+  %17 = load %System.Text.StringBuilder addrspace(1)** %this
+  %18 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %19 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
+  %20 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  %21 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
+  %22 = load %System.Text.StringBuilder addrspace(1)** %this
+  %23 = load %System.Text.StringBuilder addrspace(1)** %arg1
+  %24 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
+  %25 = load i32 addrspace(1)* %24, align 8
+  %26 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
+  store i32 %25, i32 addrspace(1)* %26
+  ret void
+}
+
+INFO:  jitting method StringBuilder::Append using LLILCJit
+Failed to read StringBuilder.Append[storeElem]
+INFO:  jitting method StringBuilder::Remove using LLILCJit
+Successfully read StringBuilder.Remove
+
+define %System.Text.StringBuilder addrspace(1)* @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc1 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32* %arg2
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg1
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32* %arg2
+  %17 = load %System.Text.StringBuilder addrspace(1)** %this
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %17)
+  %19 = load i32* %arg1
+  %20 = sub i32 %18, %19
+  %21 = icmp sle i32 %16, %20
+  br i1 %21, label %27, label %22
+
+; <label>:22                                      ; preds = %15
+  %23 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
+  unreachable
+
+; <label>:27                                      ; preds = %15
+  %28 = load %System.Text.StringBuilder addrspace(1)** %this
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %28)
+  %30 = load i32* %arg2
+  %31 = icmp ne i32 %29, %30
+  br i1 %31, label %38, label %32
+
+; <label>:32                                      ; preds = %27
+  %33 = load i32* %arg1
+  %34 = icmp ne i32 %33, 0
+  br i1 %34, label %38, label %35
+
+; <label>:35                                      ; preds = %32
+  %36 = load %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %36, i32 0)
+  %37 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %37
+
+; <label>:38                                      ; preds = %27, %32
+  %39 = load i32* %arg2
+  %40 = icmp sle i32 %39, 0
+  br i1 %40, label %47, label %41
+
+; <label>:41                                      ; preds = %38
+  %42 = load %System.Text.StringBuilder addrspace(1)** %this
+  %43 = load i32* %arg1
+  %44 = load i32* %arg2
+  %45 = addrspacecast %System.Text.StringBuilder addrspace(1)** %loc0 to %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %46 = addrspacecast i32* %loc1 to i32 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32, i32, %System.Text.StringBuilder addrspace(1)* addrspace(1)*, i32 addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %42, i32 %43, i32 %44, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, i32 addrspace(1)* %46)
+  br label %47
+
+; <label>:47                                      ; preds = %38, %41
+  %48 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %48
+}
+
+INFO:  jitting method StringBuilder::Remove using LLILCJit
+Failed to read StringBuilder.Remove[Tail call]
+INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
+Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+INFO:  jitting method Buffer::_Memmove using LLILCJit
+Failed to read Buffer._Memmove[Tail call]
+INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
+Failed to read AppDomain.SetDataHelper[loadElem]
+INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
+Successfully read AppDomain.get_LocalStore
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* @AppDomain.get_LocalStore(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.AppDomain addrspace(1)** %this
+  %6 = getelementptr inbounds %System.AppDomain addrspace(1)* %5, i32 0, i32 2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
+  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %12 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)** %this
+  %14 = getelementptr inbounds %System.AppDomain addrspace(1)* %13, i32 0, i32 2
+  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+}
+
+INFO:  jitting method Dictionary`2::.ctor using LLILCJit
+Failed to read Dictionary`2..ctor[Tail call]
+INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
+Failed to read Dictionary`2.TryGetValue[loadElemA]
+INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
+Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+INFO:  jitting method Path::NormalizePath using LLILCJit
+Failed to read Path.NormalizePath[Tail call]
+INFO:  jitting method StringBuilder::.ctor using LLILCJit
+Failed to read StringBuilder..ctor[Tail call]
+INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
+Failed to read HashHelpers.ExpandPrime[Tail call]
+INFO:  jitting method Dictionary`2::Resize using LLILCJit
+Failed to read Dictionary`2.Resize[non-const derefAddress]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
+Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
+INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
+Successfully read AppDomain.get_FusionStore
+
+define %System.AppDomainSetup addrspace(1)* @AppDomain.get_FusionStore(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.AppDomainSetup addrspace(1)* %2
+}
+
+INFO:  jitting method AppDomain::GetData using LLILCJit
+Failed to read AppDomain.GetData[convertToHelperArgumentType]
+INFO:  jitting method AppDomainSetup::Locate using LLILCJit
+Successfully read AppDomainSetup.Locate
+
+define i32 @AppDomainSetup.Locate(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i32 -1
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** %arg0
+  %7 = getelementptr inbounds %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %8 = load i16 addrspace(1)* %7
+  %9 = zext i16 %8 to i32
+  %10 = icmp ne i32 %9, 65
+  br i1 %10, label %18, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)** %arg0
+  %13 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %18, label %17
+
+; <label>:17                                      ; preds = %11
+  ret i32 0
+
+; <label>:18                                      ; preds = %5, %11
+  ret i32 -1
+}
+
+INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
+Successfully read AppDomainSetup.get_LoaderOptimizationKey
+
+define %System.String addrspace(1)* @AppDomainSetup.get_LoaderOptimizationKey() {
+entry:
+  %0 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %0
+}
+
+INFO:  jitting method String::Equals using LLILCJit
+Failed to read String.Equals[Tail call]
+INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
+Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
+Failed to read AppDomain.SetupBindingPaths[Tail call]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
+Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
+INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
+Successfully read AppDomain.GetNativeHandle
+
+define %System.AppDomainHandle @AppDomain.GetNativeHandle(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %0 = alloca %System.AppDomainHandle
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %1 = load %System.AppDomain addrspace(1)** %this
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomain addrspace(1)* %1, i32 0, i32 15
+  %4 = bitcast i64 addrspace(1)* %3 to %System.IntPtr addrspace(1)*
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.IntPtr addrspace(1)*)*)(%System.IntPtr addrspace(1)* %4)
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %2
+  %9 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %11) #1
+  unreachable
+
+; <label>:12                                      ; preds = %2
+  %13 = load %System.AppDomain addrspace(1)** %this
+  %14 = getelementptr inbounds %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %15 = load i64 addrspace(1)* %14, align 8
+  %16 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
+  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
+  %18 = load %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %18
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+}
+
+INFO:  jitting method IntPtr::IsNull using LLILCJit
+Successfully read IntPtr.IsNull
+
+define i8 @IntPtr.IsNull(%System.IntPtr addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IntPtr addrspace(1)*
+  store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
+  %0 = load %System.IntPtr addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %2 = load i16* addrspace(1)* %1, align 8
+  %3 = ptrtoint i16* %2 to i64
+  %4 = icmp eq i64 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
+INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
+Successfully read AppDomainHandle..ctor
+
+define void @AppDomainHandle..ctor(%System.AppDomainHandle addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.AppDomainHandle addrspace(1)*
+  %arg1 = alloca i64
+  store %System.AppDomainHandle addrspace(1)* %param0, %System.AppDomainHandle addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.AppDomainHandle addrspace(1)** %this
+  %1 = load i64* %arg1
+  %2 = getelementptr inbounds %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %2
+  ret void
+}
+
+INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
+Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+INFO:  jitting method Dictionary`2::.ctor using LLILCJit
+Failed to read Dictionary`2..ctor[non-const derefAddress]
+INFO:  jitting method Dictionary`2::get_Count using LLILCJit
+Successfully read Dictionary`2.get_Count
+
+define i32 @"Dictionary`2.get_Count"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = sub i32 %2, %5
+  ret i32 %6
+}
+
+INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
+Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
+INFO:  jitting method Enumerator::MoveNext using LLILCJit
+Failed to read Enumerator.MoveNext[loadElemA]
+INFO:  jitting method Enumerator::get_Current using LLILCJit
+Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
+INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
+Failed to read OrdinalComparer.GetHashCode[Tail call]
+INFO:  jitting method TextInfo::get_Invariant using LLILCJit
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
+INFO:  jitting method TextInfo::.ctor using LLILCJit
+Successfully read TextInfo..ctor
+
+define void @TextInfo..ctor(%System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.Globalization.CultureData addrspace(1)* %param1, %System.Globalization.CultureData addrspace(1)** %arg1
+  %0 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %1 = bitcast %System.Globalization.TextInfo addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %3 = load %System.Globalization.CultureData addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
+  %5 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %6 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
+  %12 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = load %System.Globalization.TextInfo addrspace(1)** %this
+  %14 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
+  %15 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %9
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
+  %18 = getelementptr inbounds %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_STEXTINFO using LLILCJit
+Successfully read CultureData.get_STEXTINFO
+
+define %System.String addrspace(1)* @CultureData.get_STEXTINFO(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.String addrspace(1)* %2
+}
+
+INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
+Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+INFO:  jitting method Enumerator::Dispose using LLILCJit
+Successfully read Enumerator.Dispose
+
+define void @Enumerator.Dispose(%"System.Collections.Generic.Dictionary`2+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::InitializeSwitches using LLILCJit
+Successfully read CompatibilitySwitches.InitializeSwitches
+
+define void @CompatibilitySwitches.InitializeSwitches() {
+entry:
+  %0 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %5 = getelementptr inbounds i8 addrspace(1)* %4, i64 1989
+  %6 = addrspacecast i8 addrspace(1)* %5 to i8*
+  store i8 %3, i8* %6
+  %7 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1990
+  %13 = addrspacecast i8 addrspace(1)* %12 to i8*
+  store i8 %10, i8* %13
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1988
+  %20 = addrspacecast i8 addrspace(1)* %19 to i8*
+  store i8 %17, i8* %20
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %22 = getelementptr inbounds i8 addrspace(1)* %21, i64 1988
+  %23 = addrspacecast i8 addrspace(1)* %22 to i8*
+  %24 = load i8* %23
+  %25 = zext i8 %24 to i32
+  %26 = icmp ne i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %entry
+  %28 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  br label %32
+
+; <label>:31                                      ; preds = %entry
+  br label %32
+
+; <label>:32                                      ; preds = %27, %31
+  %33 = phi i32 [ %30, %27 ], [ 1, %31 ]
+  %34 = trunc i32 %33 to i8
+  %35 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %36 = getelementptr inbounds i8 addrspace(1)* %35, i64 1987
+  %37 = addrspacecast i8 addrspace(1)* %36 to i8*
+  store i8 %34, i8* %37
+  %38 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %39 = getelementptr inbounds i8 addrspace(1)* %38, i64 1986
+  %40 = addrspacecast i8 addrspace(1)* %39 to i8*
+  store i8 1, i8* %40
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
+Failed to read CompatibilitySwitches.IsCompatibilitySwitchSet[Return refany or value class]
+INFO:  jitting method AppDomain::IsCompatibilitySwitchSet using LLILCJit
+Successfully read AppDomain.IsCompatibilitySwitchSet
+
+define %"System.Nullable`1[System.Boolean]" @AppDomain.IsCompatibilitySwitchSet(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca %"System.Nullable`1[System.Boolean]"
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %7, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
+  br label %28
+
+; <label>:7                                       ; preds = %entry
+  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 14
+  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
+  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
+  br i1 %12, label %23, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.AppDomain addrspace(1)** %this
+  %15 = getelementptr inbounds %System.AppDomain addrspace(1)* %14, i32 0, i32 14
+  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = load %System.String addrspace(1)** %arg1
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
+  br i1 %NullCheck, label %18, label %ThrowNullRef
+
+; <label>:18                                      ; preds = %13
+  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
+  %22 = zext i8 %21 to i32
+  br label %24
+
+; <label>:23                                      ; preds = %7
+  br label %24
+
+; <label>:24                                      ; preds = %18, %23
+  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
+  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
+  %27 = trunc i32 %26 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
+  br label %28
+
+; <label>:28                                      ; preds = %5, %24
+  %29 = load %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %29
+
+ThrowNullRef:                                     ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Dictionary`2::ContainsKey using LLILCJit
+Successfully read Dictionary`2.ContainsKey
+
+define i8 @"Dictionary`2.ContainsKey"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  %3 = icmp slt i32 %2, 0
+  %4 = sext i1 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+}
+
+INFO:  jitting method Nullable`1::.ctor using LLILCJit
+Successfully read Nullable`1..ctor
+
+define void @"Nullable`1..ctor"(%"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %arg1 = alloca i8
+  store %"System.Nullable`1[System.Boolean]" addrspace(1)* %param0, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %1 = load i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
+INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
+Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
+Successfully read AppDomainSetup.InternalGetApplicationTrust
+
+define %System.Security.Policy.ApplicationTrust addrspace(1)* @AppDomainSetup.InternalGetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
+  %8 = load %System.String addrspace(1)* addrspace(1)* %7, align 8
+  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+}
+
+INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
+Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Failed to read PermissionSet..ctor[Tail call]
+INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
+Successfully read ApplicationTrust..ctor
+
+define void @ApplicationTrust..ctor(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.ApplicationTrust addrspace(1)* %0 to %System.Security.Policy.EvidenceBase addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.EvidenceBase addrspace(1)*)*)(%System.Security.Policy.EvidenceBase addrspace(1)* %1)
+  %2 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %3 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %2, %System.Security.PermissionSet addrspace(1)* %3)
+  %4 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %5 = call %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
+  %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
+  %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  ret void
+}
+
+INFO:  jitting method EvidenceBase::.ctor using LLILCJit
+Failed to read EvidenceBase..ctor[Tail call]
+INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
+Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 72
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 32
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Copy using LLILCJit
+Successfully read PermissionSet.Copy
+
+define %System.Security.PermissionSet addrspace(1)* @PermissionSet.Copy(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)** %this
+  %1 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %1, %System.Security.PermissionSet addrspace(1)* %0)
+  ret %System.Security.PermissionSet addrspace(1)* %1
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Failed to read PermissionSet..ctor[Tail call]
+INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
+Successfully read PolicyStatement.ValidProperties
+
+define i8 @PolicyStatement.ValidProperties(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32* %arg0
+  %1 = and i32 %0, -4
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %5)
+  %7 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %7, %System.String addrspace(1)* %6)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %7) #0
+  unreachable
+}
+
+INFO:  jitting method ApplicationTrust::set_DefaultGrantSet using LLILCJit
+Successfully read ApplicationTrust.set_DefaultGrantSet
+
+define void @ApplicationTrust.set_DefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %6
+  ret void
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
+  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
+  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
+
+; <label>:15                                      ; preds = %7
+  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
+  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
+  store i32 %17, i32 addrspace(1)* %18
+  ret void
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method PolicyStatement::get_PermissionSet using LLILCJit
+Successfully read PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca i8
+  %loc1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc2 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc0
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %1 = addrspacecast i8* %loc0 to i8 addrspace(1)*
+  %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
+  %3 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %5 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64 addrspace(1)* %6
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64* %9
+  %11 = add i64 %10, 32
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64* %12
+  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
+  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = load i8* %loc0
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %16
+  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
+  br label %23
+
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
+  %25 = load %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %25
+}
+
+INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
+Failed to read SecurityManager.GetSpecialFlags[loadElem]
+INFO:  jitting method List`1::.ctor using LLILCJit
+Failed to read List`1..ctor[non-const derefAddress]
+INFO:  jitting method List`1::AsReadOnly using LLILCJit
+Failed to read List`1.AsReadOnly[non-const derefAddress]
+INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
+Successfully read ReadOnlyCollection`1..ctor
+
+define void @"ReadOnlyCollection`1..ctor"(%"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  store %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %param1, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %0 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %3 = icmp ne %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 7)
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
+INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
+Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
+INFO:  jitting method AppDomain::RunInitializer using LLILCJit
+Failed to read AppDomain.RunInitializer[non-const derefAddress]
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Failed to read PermissionSet..ctor[Tail call]
+INFO:  jitting method BringUpTest::Main using LLILCJit
+Failed to read BringUpTest.Main[abs]
+INFO:  jitting method BringUpTest::FPRem using LLILCJit
+Successfully read BringUpTest.FPRem
+
+define float @BringUpTest.FPRem(float %param0, float %param1) {
+entry:
+  %arg0 = alloca float
+  %arg1 = alloca float
+  store float %param0, float* %arg0
+  store float %param1, float* %arg1
+  %0 = load float* %arg0
+  %1 = load float* %arg1
+  %2 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (float, float)*)(float %0, float %1)
+  ret float %2
+}
+
+INFO:  jitting method Console::WriteLine using LLILCJit
+Failed to read Console.WriteLine[Tail call]
+INFO:  jitting method Console::get_Out using LLILCJit
+Failed to read Console.get_Out[Call HasTypeArg]
+INFO:  jitting method Console::.cctor using LLILCJit
+Successfully read Console..cctor
+
+define void @Console..cctor() {
+entry:
+  %0 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %0)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method Console::EnsureInitialized using LLILCJit
+Failed to read Console.EnsureInitialized[Call HasTypeArg]
+INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
+Failed to read Console.<get_Out>b__2[Tail call]
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
+Successfully read ConsolePal.GetStandardFile
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.GetStandardFile(i64 %param0, i32 %param1) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca i32
+  store i64 %param0, i64* %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i64* %arg0
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %0, i64 0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %18, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64* %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  %6 = load i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %5, i64 %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %4
+  %11 = load i32* %arg1
+  %12 = icmp eq i32 %11, 1
+  br i1 %12, label %20, label %13
+
+; <label>:13                                      ; preds = %10
+  %14 = load i64* %arg0
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64)*)(i64 %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %entry, %4, %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %19 = load %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  ret %System.IO.Stream addrspace(1)* %19
+
+; <label>:20                                      ; preds = %10, %13
+  %21 = load i64* %arg0
+  %22 = load i32* %arg1
+  %23 = call %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, i64, i32)*)(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %23, i64 %21, i32 %22)
+  %24 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %23 to %System.IO.Stream addrspace(1)*
+  ret %System.IO.Stream addrspace(1)* %24
+}
+
+INFO:  jitting method IntPtr::op_Equality using LLILCJit
+Successfully read IntPtr.op_Equality
+
+define i8 @IntPtr.op_Equality(i64 %param0, i64 %param1) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca i64
+  store i64 %param0, i64* %arg0
+  store i64 %param1, i64* %arg1
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16* addrspace(1)* %3, align 8
+  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
+  %7 = getelementptr inbounds i8 addrspace(1)* %6, i64 0
+  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
+  %9 = load i16* addrspace(1)* %8, align 8
+  %10 = icmp eq i16* %4, %9
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  ret i8 %12
+}
+
+INFO:  jitting method Interop::.cctor using LLILCJit
+Successfully read Interop..cctor
+
+define void @Interop..cctor() {
+entry:
+  %0 = alloca i64
+  %1 = bitcast i64* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %1, i8 0, i64 0, i32 0, i1 false)
+  %2 = addrspacecast i64* %0 to i64 addrspace(1)*
+  %3 = bitcast i64 addrspace(1)* %2 to %System.IntPtr addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IntPtr addrspace(1)*, i32)*)(%System.IntPtr addrspace(1)* %3, i32 -1)
+  %4 = load i64* %0
+  store i64 %4, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  ret void
+}
+
+INFO:  jitting method IntPtr::.ctor using LLILCJit
+Successfully read IntPtr..ctor
+
+define void @IntPtr..ctor(%System.IntPtr addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IntPtr addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IntPtr addrspace(1)** %this
+  %1 = load i32* %arg1
+  %2 = sext i32 %1 to i64
+  %3 = inttoptr i64 %2 to i16*
+  %4 = getelementptr inbounds %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
+Successfully read ConsolePal.ConsoleHandleIsWritable
+
+define i8 @ConsolePal.ConsoleHandleIsWritable(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  %loc0 = alloca i32
+  %loc1 = alloca i8
+  store i64 %param0, i64* %arg0
+  store i8 65, i8* %loc1
+  %0 = load i64* %arg0
+  %1 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %2 = ptrtoint i8 addrspace(1)* %1 to i64
+  %3 = addrspacecast i32* %loc0 to i32 addrspace(1)*
+  %4 = inttoptr i64 %2 to i8*
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %0, i8* %4, i32 0, i32 addrspace(1)* %3, i64 0)
+  %6 = icmp ugt i32 %5, 0
+  %7 = sext i1 %6 to i32
+  %8 = trunc i32 %7 to i8
+  ret i8 %8
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
+Successfully read WindowsConsoleStream..ctor
+
+define void @WindowsConsoleStream..ctor(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, i64 %param1, i32 %param2) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  %arg1 = alloca i64
+  %arg2 = alloca i32
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = load i32* %arg2
+  %2 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
+  %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %4 = load i64* %arg1
+  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %5
+  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %7 = load i64* %arg1
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
+  %9 = icmp eq i32 %8, 3
+  %10 = sext i1 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
+  store i8 %11, i8 addrspace(1)* %12
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::.ctor using LLILCJit
+Successfully read ConsoleStream..ctor
+
+define void @ConsoleStream..ctor(%System.IO.ConsoleStream addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  %2 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %3 = load i32* %arg1
+  %4 = and i32 %3, 1
+  %5 = icmp eq i32 %4, 1
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  %8 = getelementptr inbounds %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %8
+  %9 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %10 = load i32* %arg1
+  %11 = and i32 %10, 2
+  %12 = icmp eq i32 %11, 2
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  %15 = getelementptr inbounds %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
+  store i8 %14, i8 addrspace(1)* %15
+  ret void
+}
+
+INFO:  jitting method Stream::.ctor using LLILCJit
+Failed to read Stream..ctor[Tail call]
+INFO:  jitting method mincore::GetFileType using LLILCJit
+Failed to read mincore.GetFileType[Tail call]
+INFO:  jitting method Console::CreateOutputWriter using LLILCJit
+Failed to read Console.CreateOutputWriter[Tail call]
+INFO:  jitting method Stream::.cctor using LLILCJit
+Successfully read Stream..cctor
+
+define void @Stream..cctor() {
+entry:
+  %0 = call %"System.IO.Stream+NullStream" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.IO.Stream+NullStream" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.IO.Stream+NullStream" addrspace(1)*)*)(%"System.IO.Stream+NullStream" addrspace(1)* %0)
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %2 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %3 = getelementptr inbounds i8 addrspace(1)* %2, i64 2680
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(i8 addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method NullStream::.ctor using LLILCJit
+Failed to read NullStream..ctor[Tail call]
+INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
+Failed to read mincore.GetConsoleOutputCP[Tail call]
+INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
+Successfully read ConsolePal.GetEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.GetEncoding(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %System.Text.Encoding addrspace(1)*
+  store i32 %param0, i32* %arg0
+  %0 = load i32* %arg0
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  store %System.Text.Encoding addrspace(1)* %1, %System.Text.Encoding addrspace(1)** %loc0
+  %2 = load %System.Text.Encoding addrspace(1)** %loc0
+  %3 = call %System.Text.ConsoleEncoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.ConsoleEncoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.ConsoleEncoding addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.ConsoleEncoding addrspace(1)* %3, %System.Text.Encoding addrspace(1)* %2)
+  %4 = bitcast %System.Text.ConsoleEncoding addrspace(1)* %3 to %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %4, %System.Text.Encoding addrspace(1)** %loc0
+  br label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.Encoding addrspace(1)** %loc0
+  ret %System.Text.Encoding addrspace(1)* %6
+}
+
+INFO:  jitting method Encoding::GetEncoding using LLILCJit
+Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
+INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
+Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+INFO:  jitting method EncodingProvider::.cctor using LLILCJit
+Successfully read EncodingProvider..cctor
+
+define void @EncodingProvider..cctor() {
+entry:
+  %0 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 2384
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Object addrspace(1)*)*)(i8 addrspace(1)* %2, %System.Object addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_InternalSyncObject using LLILCJit
+Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
+INFO:  jitting method Hashtable::.ctor using LLILCJit
+Failed to read Hashtable..ctor[Volatile store]
+INFO:  jitting method Hashtable::get_Item using LLILCJit
+Failed to read Hashtable.get_Item[loadElemA]
+INFO:  jitting method Hashtable::InitHash using LLILCJit
+Successfully read Hashtable.InitHash
+
+define i32 @Hashtable.InitHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, i32 %param2, i32 addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32 addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 addrspace(1)* %param3, i32 addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)** %arg1
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64 addrspace(1)* %2
+  %4 = add i64 %3, 72
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64* %8
+  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %12 = and i32 %11, 2147483647
+  store i32 %12, i32* %loc0
+  %13 = load i32 addrspace(1)** %arg3
+  %14 = load i32* %loc0
+  store i32 %14, i32 addrspace(1)* %13, align 8
+  %15 = load i32 addrspace(1)** %arg4
+  %16 = load i32 addrspace(1)** %arg3
+  %17 = load i32 addrspace(1)* %16, align 8
+  %18 = mul i32 %17, 101
+  %19 = load i32* %arg2
+  %20 = sub i32 %19, 1
+  %21 = urem i32 %18, %20
+  %22 = add i32 1, %21
+  store i32 %22, i32 addrspace(1)* %15, align 8
+  %23 = load i32* %loc0
+  ret i32 %23
+}
+
+INFO:  jitting method Hashtable::GetHash using LLILCJit
+Failed to read Hashtable.GetHash[Tail call]
+INFO:  jitting method Int32::GetHashCode using LLILCJit
+Successfully read Int32.GetHashCode
+
+define i32 @Int32.GetHashCode(%System.Int32 addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  %0 = load %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32* %1, align 8
+  ret i32 %2
+}
+
+INFO:  jitting method Encoding::get_UTF8 using LLILCJit
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
+INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
+Successfully read UTF8Encoding.SetDefaultFallbacks
+
+define void @UTF8Encoding.SetDefaultFallbacks(%System.Text.UTF8Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  %0 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %8 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
+  %9 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+  ret void
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
+  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
+  %17 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
+  %18 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
+  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
+  %22 = getelementptr inbounds %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+  ret void
+}
+
+INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
+Failed to read EncoderReplacementFallback..ctor[storeElem]
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Failed to read Char.IsSurrogate[Tail call]
+INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
+Failed to read DecoderReplacementFallback..ctor[storeElem]
+INFO:  jitting method Hashtable::Add using LLILCJit
+Failed to read Hashtable.Add[Tail call]
+INFO:  jitting method Hashtable::Insert using LLILCJit
+Failed to read Hashtable.Insert[loadElemA]
+INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
+Successfully read ConsoleEncoding..ctor
+
+define void @ConsoleEncoding..ctor(%System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = bitcast %System.Text.ConsoleEncoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
+  %2 = load %System.Text.ConsoleEncoding addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Failed to read Encoding..ctor[Tail call]
+INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
+Successfully read Encoding.SetDefaultFallbacks
+
+define void @Encoding.SetDefaultFallbacks(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)** %this
+  %1 = load %System.Text.Encoding addrspace(1)** %this
+  %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
+  %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
+  %4 = getelementptr inbounds %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
+  %5 = load %System.Text.Encoding addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)** %this
+  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
+  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
+  %9 = getelementptr inbounds %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
+Successfully read InternalEncoderBestFitFallback..ctor
+
+define void @InternalEncoderBestFitFallback..ctor(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.InternalEncoderBestFitFallback addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.InternalEncoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %0 to %System.Text.EncoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
+  %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %6
+  ret void
+}
+
+INFO:  jitting method EncoderFallback::.ctor using LLILCJit
+Failed to read EncoderFallback..ctor[Tail call]
+INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
+Successfully read InternalDecoderBestFitFallback..ctor
+
+define void @InternalDecoderBestFitFallback..ctor(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.InternalDecoderBestFitFallback addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %1
+  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
+  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)** %arg1
+  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
+  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
+  ret void
+}
+
+INFO:  jitting method DecoderFallback::.ctor using LLILCJit
+Failed to read DecoderFallback..ctor[Tail call]
+INFO:  jitting method StreamWriter::.ctor using LLILCJit
+Failed to read StreamWriter..ctor[Tail call]
+INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
+Successfully read ConsoleStream.get_CanWrite
+
+define i8 @ConsoleStream.get_CanWrite(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
+INFO:  jitting method StreamWriter::Init using LLILCJit
+Successfully read StreamWriter.Init
+
+define void @StreamWriter.Init(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = load %System.IO.Stream addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
+  %3 = load %System.IO.StreamWriter addrspace(1)** %this
+  %4 = load %System.Text.Encoding addrspace(1)** %arg2
+  %5 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
+  %6 = load %System.IO.StreamWriter addrspace(1)** %this
+  %7 = load %System.IO.StreamWriter addrspace(1)** %this
+  %8 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
+  %9 = load %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64 addrspace(1)* %10
+  %12 = add i64 %11, 96
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64* %16
+  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
+  %20 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
+  %21 = load i32* %arg3
+  %22 = icmp sge i32 %21, 128
+  br i1 %22, label %24, label %23
+
+; <label>:23                                      ; preds = %entry
+  store i32 128, i32* %arg3
+  br label %24
+
+; <label>:24                                      ; preds = %entry, %23
+  %25 = load %System.IO.StreamWriter addrspace(1)** %this
+  %26 = load i32* %arg3
+  %27 = sext i32 %26 to i64
+  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
+  %29 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %30 = load %System.IO.StreamWriter addrspace(1)** %this
+  %31 = load %System.IO.StreamWriter addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
+  %33 = load %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
+  %34 = load i32* %arg3
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
+  %36 = load i64 addrspace(1)* %35
+  %37 = add i64 %36, 96
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64* %38
+  %40 = add i64 %39, 16
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64* %41
+  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
+  %45 = sext i32 %44 to i64
+  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
+  %47 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)** %this
+  %49 = load i32* %arg3
+  %50 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
+  store i32 %49, i32 addrspace(1)* %50
+  %51 = load %System.IO.StreamWriter addrspace(1)** %this
+  %52 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
+  %53 = load %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
+  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
+  %55 = load i64 addrspace(1)* %54
+  %56 = add i64 %55, 64
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64* %57
+  %59 = add i64 %58, 40
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64* %60
+  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
+  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %84, label %66
+
+; <label>:66                                      ; preds = %24
+  %67 = load %System.IO.StreamWriter addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
+  %69 = load %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64 addrspace(1)* %70
+  %72 = add i64 %71, 72
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64* %73
+  %75 = add i64 %74, 8
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64* %76
+  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
+  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
+  %80 = icmp sle i64 %79, 0
+  br i1 %80, label %84, label %81
+
+; <label>:81                                      ; preds = %66
+  %82 = load %System.IO.StreamWriter addrspace(1)** %this
+  %83 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %83
+  br label %84
+
+; <label>:84                                      ; preds = %24, %66, %81
+  %85 = load %System.IO.StreamWriter addrspace(1)** %this
+  %86 = load i8* %arg4
+  %87 = zext i8 %86 to i32
+  %88 = icmp eq i32 %87, 0
+  %89 = sext i1 %88 to i32
+  %90 = trunc i32 %89 to i8
+  %91 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
+  store i8 %90, i8 addrspace(1)* %91
+  ret void
+}
+
+INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
+Failed to read ConsoleEncoding.GetEncoder[Tail call]
+INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
+Successfully read UTF8Encoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @UTF8Encoding.GetEncoder(%System.Text.UTF8Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  %0 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = call %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)*)*)(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %1, %System.Text.UTF8Encoding addrspace(1)* %0)
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %1 to %System.Text.Encoder addrspace(1)*
+  ret %System.Text.Encoder addrspace(1)* %2
+}
+
+INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
+Failed to read UTF8Encoder..ctor[Tail call]
+INFO:  jitting method UTF8Encoder::Reset using LLILCJit
+Failed to read UTF8Encoder.Reset[Tail call]
+INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
+Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
+Successfully read UTF8Encoding.GetMaxByteCount
+
+define i32 @UTF8Encoding.GetMaxByteCount(%System.Text.UTF8Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i64
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg1
+  %9 = sext i32 %8 to i64
+  %10 = add i64 %9, 1
+  store i64 %10, i64* %loc0
+  %11 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
+  %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64* %20
+  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
+  %24 = icmp sle i32 %23, 1
+  br i1 %24, label %42, label %25
+
+; <label>:25                                      ; preds = %7
+  %26 = load i64* %loc0
+  %27 = load %System.Text.UTF8Encoding addrspace(1)** %this
+  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
+  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
+  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64 addrspace(1)* %30
+  %32 = add i64 %31, 64
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64* %33
+  %35 = add i64 %34, 40
+  %36 = inttoptr i64 %35 to i64*
+  %37 = load i64* %36
+  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
+  %40 = sext i32 %39 to i64
+  %41 = mul i64 %26, %40
+  store i64 %41, i64* %loc0
+  br label %42
+
+; <label>:42                                      ; preds = %7, %25
+  %43 = load i64* %loc0
+  %44 = mul i64 %43, 3
+  store i64 %44, i64* %loc0
+  %45 = load i64* %loc0
+  %46 = icmp sle i64 %45, 2147483647
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %42
+  %48 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
+  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+  unreachable
+
+; <label>:52                                      ; preds = %42
+  %53 = load i64* %loc0
+  %54 = trunc i64 %53 to i32
+  ret i32 %54
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
+INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
+Successfully read EncoderReplacementFallback.get_MaxCharCount
+
+define i32 @EncoderReplacementFallback.get_MaxCharCount(%System.Text.EncoderReplacementFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
+  store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderReplacementFallback addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32 addrspace(1)* %3
+  ret i32 %4
+}
+
+INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
+Successfully read ConsoleStream.get_CanSeek
+
+define i8 @ConsoleStream.get_CanSeek(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  ret i8 0
+}
+
+INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
+Failed to read StreamWriter.set_AutoFlush[Tail call]
+INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
+Successfully read StreamWriter.CheckAsyncTaskInProgress
+
+define void @StreamWriter.CheckAsyncTaskInProgress(%System.IO.StreamWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  %0 = load %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %3 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %15, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %entry, %7
+  ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StreamWriter::Flush using LLILCJit
+Failed to read StreamWriter.Flush[Tail call]
+INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
+Successfully read SyncTextWriter.GetSynchronizedTextWriter
+
+define %System.IO.TextWriter addrspace(1)* @SyncTextWriter.GetSynchronizedTextWriter(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %arg0
+  %0 = load %System.IO.TextWriter addrspace(1)** %arg0
+  %1 = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.TextWriter addrspace(1)** %arg0
+  %7 = call %System.IO.SyncTextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.SyncTextWriter addrspace(1)* (i64, %System.IO.TextWriter addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.IO.TextWriter addrspace(1)* %6)
+  %8 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %7, null
+  br i1 %8, label %13, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = load %System.IO.TextWriter addrspace(1)** %arg0
+  %11 = call %System.IO.SyncTextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.SyncTextWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.SyncTextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.SyncTextWriter addrspace(1)* %11, %System.IO.TextWriter addrspace(1)* %10)
+  %12 = bitcast %System.IO.SyncTextWriter addrspace(1)* %11 to %System.IO.TextWriter addrspace(1)*
+  ret %System.IO.TextWriter addrspace(1)* %12
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.IO.TextWriter addrspace(1)** %arg0
+  ret %System.IO.TextWriter addrspace(1)* %14
+}
+
+INFO:  jitting method SyncTextWriter::.ctor using LLILCJit
+Successfully read SyncTextWriter..ctor
+
+define void @SyncTextWriter..ctor(%System.IO.SyncTextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.SyncTextWriter addrspace(1)*
+  %arg1 = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.SyncTextWriter addrspace(1)* %param0, %System.IO.SyncTextWriter addrspace(1)** %this
+  store %System.IO.TextWriter addrspace(1)* %param1, %System.IO.TextWriter addrspace(1)** %arg1
+  %0 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
+  %3 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %4 = load %System.IO.TextWriter addrspace(1)** %arg1
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64 addrspace(1)* %5
+  %7 = add i64 %6, 64
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64* %8
+  %10 = add i64 %9, 32
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64* %11
+  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
+  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
+  %16 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %17 = load %System.IO.TextWriter addrspace(1)** %arg1
+  %18 = getelementptr inbounds %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  ret void
+}
+
+INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
+Successfully read TextWriter.get_FormatProvider
+
+define %System.IFormatProvider addrspace(1)* @TextWriter.get_FormatProvider(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %4
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
+  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.TextWriter addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
+  %12 = load %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.IFormatProvider addrspace(1)* %12
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Thread::get_CurrentThread using LLILCJit
+Failed to read Thread.get_CurrentThread[Tail call]
+INFO:  jitting method Object::Finalize using LLILCJit
+Successfully read Object.Finalize
+
+define void @Object.Finalize(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method CriticalFinalizerObject::Finalize using LLILCJit
+Successfully read CriticalFinalizerObject.Finalize
+
+define void @CriticalFinalizerObject.Finalize(%System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)*
+  store %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)* %param0, %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)** %this
+  br label %0
+
+; <label>:0                                       ; preds = %entry
+  %1 = load %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)** %this
+  %2 = bitcast %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2)
+  br label %3
+
+; <label>:3                                       ; preds = %0
+  ret void
+}
+
+INFO:  jitting method Thread::Finalize using LLILCJit
+Successfully read Thread.Finalize
+
+define void @Thread.Finalize(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = load %System.Threading.Thread addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %0)
+  br label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = load %System.Threading.Thread addrspace(1)** %this
+  %3 = bitcast %System.Threading.Thread addrspace(1)* %2 to %System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)*)*)(%System.Runtime.ConstrainedExecution.CriticalFinalizerObject addrspace(1)* %3)
+  br label %4
+
+; <label>:4                                       ; preds = %1
+  ret void
+}
+
+INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
+Failed to read Thread.get_CurrentCulture[Tail call]
+INFO:  jitting method AppDomain::get_Flags using LLILCJit
+Successfully read AppDomain.get_Flags
+
+define i32 @AppDomain.get_Flags() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 123)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1980
+  %2 = addrspacecast i8 addrspace(1)* %1 to i32*
+  %3 = load i32* %2
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 123)
+  %8 = getelementptr inbounds i8 addrspace(1)* %7, i64 1980
+  %9 = addrspacecast i8 addrspace(1)* %8 to i32*
+  store i32 %6, i32* %9
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 123)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1980
+  %13 = addrspacecast i8 addrspace(1)* %12 to i32*
+  %14 = load i32* %13
+  ret i32 %14
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
+Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
+INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
+Successfully read SyncTextWriter.WriteLine
+
+define void @SyncTextWriter.WriteLine(%System.IO.SyncTextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.SyncTextWriter addrspace(1)*
+  %arg1 = alloca float
+  %loc0 = alloca %System.Object addrspace(1)*
+  %loc1 = alloca i8
+  store %System.IO.SyncTextWriter addrspace(1)* %param0, %System.IO.SyncTextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  store i8 0, i8* %loc1
+  %0 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.Object addrspace(1)* addrspace(1)* %1, align 8
+  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
+  %3 = load %System.Object addrspace(1)** %loc0
+  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
+  %5 = load %System.IO.SyncTextWriter addrspace(1)** %this
+  %6 = getelementptr inbounds %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load float* %arg1
+  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
+  %10 = load i64 addrspace(1)* %9
+  %11 = add i64 %10, 96
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64* %12
+  %14 = add i64 %13, 48
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64* %15
+  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
+  br label %18
+
+; <label>:18                                      ; preds = %entry
+  %19 = load i8* %loc1
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %18, %22
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  ret void
+}
+
+INFO:  jitting method TextWriter::WriteLine using LLILCJit
+Failed to read TextWriter.WriteLine[Tail call]
+INFO:  jitting method TextWriter::Write using LLILCJit
+Failed to read TextWriter.Write[Tail call]
+INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
+Failed to read NumberFormatInfo.GetInstance[Tail call]
+INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
+Successfully read CultureInfo.get_NumberFormat
+
+define %System.Globalization.NumberFormatInfo addrspace(1)* @CultureInfo.get_NumberFormat(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
+  br i1 %3, label %19, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
+  %7 = load %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
+  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
+  %12 = load i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = trunc i32 %13 to i8
+  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
+  store i8 %14, i8 addrspace(1)* %15
+  %16 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %4
+  %20 = load %System.Globalization.CultureInfo addrspace(1)** %this
+  %21 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+}
+
+INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
+Failed to read NumberFormatInfo..ctor[storeElem]
+INFO:  jitting method CultureData::GetNFIValues using LLILCJit
+Successfully read CultureData.GetNFIValues
+
+define void @CultureData.GetNFIValues(%System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.NumberFormatInfo addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %param1, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %65, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %8 = load %System.String addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
+  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %11 = load %System.Globalization.CultureData addrspace(1)** %this
+  %12 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
+  %13 = load %System.String addrspace(1)* addrspace(1)* %12, align 8
+  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
+  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %16 = load %System.Globalization.CultureData addrspace(1)** %this
+  %17 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
+  %18 = load %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
+  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %21 = load %System.Globalization.CultureData addrspace(1)** %this
+  %22 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %23 = load %System.String addrspace(1)* addrspace(1)* %22, align 8
+  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %26 = load %System.Globalization.CultureData addrspace(1)** %this
+  %27 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
+  %28 = load i32 addrspace(1)* %27, align 8
+  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
+  store i32 %28, i32 addrspace(1)* %29
+  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %31 = load %System.Globalization.CultureData addrspace(1)** %this
+  %32 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
+  %33 = load i32 addrspace(1)* %32, align 8
+  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
+  store i32 %33, i32 addrspace(1)* %34
+  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %36 = load %System.Globalization.CultureData addrspace(1)** %this
+  %37 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
+  %38 = load %System.String addrspace(1)* addrspace(1)* %37, align 8
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %40 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %41 = load %System.Globalization.CultureData addrspace(1)** %this
+  %42 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
+  %43 = load %System.String addrspace(1)* addrspace(1)* %42, align 8
+  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
+  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %46 = load %System.Globalization.CultureData addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
+  %48 = load %System.String addrspace(1)* addrspace(1)* %47, align 8
+  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
+  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %51 = load %System.Globalization.CultureData addrspace(1)** %this
+  %52 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
+  %53 = load i32 addrspace(1)* %52, align 8
+  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
+  store i32 %53, i32 addrspace(1)* %54
+  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %56 = load %System.Globalization.CultureData addrspace(1)** %this
+  %57 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
+  %58 = load i32 addrspace(1)* %57, align 8
+  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
+  store i32 %58, i32 addrspace(1)* %59
+  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %61 = load %System.Globalization.CultureData addrspace(1)** %this
+  %62 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
+  %63 = load i32 addrspace(1)* %62, align 8
+  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
+  store i32 %63, i32 addrspace(1)* %64
+  br label %76
+
+; <label>:65                                      ; preds = %entry
+  %66 = load %System.Globalization.CultureData addrspace(1)** %this
+  %67 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
+  %68 = load %System.String addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %70 = load %System.Globalization.CultureData addrspace(1)** %this
+  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
+  %72 = zext i8 %71 to i32
+  %73 = trunc i32 %72 to i8
+  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
+  %75 = zext i8 %74 to i32
+  br label %76
+
+; <label>:76                                      ; preds = %4, %65
+  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %78 = load %System.Globalization.CultureData addrspace(1)** %this
+  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
+  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
+  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %82 = load %System.Globalization.CultureData addrspace(1)** %this
+  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
+  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
+  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %86 = load %System.Globalization.CultureData addrspace(1)** %this
+  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
+  store i32 %87, i32 addrspace(1)* %88
+  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %90 = load %System.Globalization.CultureData addrspace(1)** %this
+  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
+  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
+  store i32 %91, i32 addrspace(1)* %92
+  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %94 = load %System.Globalization.CultureData addrspace(1)** %this
+  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
+  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
+  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %98 = load %System.Globalization.CultureData addrspace(1)** %this
+  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
+  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
+  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %102 = load %System.Globalization.CultureData addrspace(1)** %this
+  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
+  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
+  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %106 = load %System.Globalization.CultureData addrspace(1)** %this
+  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
+  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
+  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %110 = load %System.Globalization.CultureData addrspace(1)** %this
+  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
+  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
+  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
+  %116 = load i32 addrspace(1)* %115, align 8
+  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
+  store i32 %116, i32 addrspace(1)* %117
+  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
+  %121 = load %System.String addrspace(1)* addrspace(1)* %120, align 8
+  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
+  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
+  %126 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
+  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
+  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
+  %131 = load %System.String addrspace(1)* addrspace(1)* %130, align 8
+  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
+  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
+  %135 = load %System.String addrspace(1)* addrspace(1)* %134, align 8
+  %136 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %136, label %144, label %137
+
+; <label>:137                                     ; preds = %76
+  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
+  %140 = load %System.String addrspace(1)* addrspace(1)* %139, align 8
+  %141 = getelementptr inbounds %System.String addrspace(1)* %140, i32 0, i32 1
+  %142 = load i32 addrspace(1)* %141
+  %143 = icmp ne i32 %142, 0
+  br i1 %143, label %148, label %144
+
+; <label>:144                                     ; preds = %76, %137
+  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %146 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
+  br label %148
+
+; <label>:148                                     ; preds = %137, %144
+  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
+  %151 = load %System.String addrspace(1)* addrspace(1)* %150, align 8
+  %152 = icmp eq %System.String addrspace(1)* %151, null
+  br i1 %152, label %160, label %153
+
+; <label>:153                                     ; preds = %148
+  %154 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
+  %156 = load %System.String addrspace(1)* addrspace(1)* %155, align 8
+  %157 = getelementptr inbounds %System.String addrspace(1)* %156, i32 0, i32 1
+  %158 = load i32 addrspace(1)* %157
+  %159 = icmp ne i32 %158, 0
+  br i1 %159, label %166, label %160
+
+; <label>:160                                     ; preds = %148, %153
+  %161 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %162 = load %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
+  %164 = load %System.String addrspace(1)* addrspace(1)* %163, align 8
+  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
+  br label %166
+
+; <label>:166                                     ; preds = %153, %160
+  ret void
+}
+
+INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
+Failed to read CultureData.get_IsInvariantCulture[Tail call]
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
+INFO:  jitting method CultureData::get_WAGROUPING using LLILCJit
+Successfully read CultureData.get_WAGROUPING
+
+define %"System.Int32[]" addrspace(1)* @CultureData.get_WAGROUPING(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %2 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
+  br i1 %3, label %10, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
+  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
+  %9 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %4
+  %11 = load %System.Globalization.CultureData addrspace(1)** %this
+  %12 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
+  %13 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
+  ret %"System.Int32[]" addrspace(1)* %13
+}
+
+INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
+Failed to read CultureData.DoGetLocaleInfo[Tail call]
+INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32* %arg2
+  %6 = or i32 %5, -2147483648
+  store i32 %6, i32* %arg2
+  br label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.String addrspace(1)** %arg1
+  %9 = load i32* %arg2
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %8, i32 %9)
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)** %loc0
+  %12 = icmp ne %System.String addrspace(1)* %11, null
+  br i1 %12, label %15, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc0
+  br label %15
+
+; <label>:15                                      ; preds = %7, %13
+  %16 = load %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %16
+}
+
+INFO:  jitting method CultureData::ConvertWin32GroupString using LLILCJit
+Failed to read CultureData.ConvertWin32GroupString[storeElem]
+INFO:  jitting method CultureData::get_WAMONGROUPING using LLILCJit
+Successfully read CultureData.get_WAMONGROUPING
+
+define %"System.Int32[]" addrspace(1)* @CultureData.get_WAMONGROUPING(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %2 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
+  br i1 %3, label %10, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
+  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
+  %9 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %4
+  %11 = load %System.Globalization.CultureData addrspace(1)** %this
+  %12 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
+  %13 = load %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
+  ret %"System.Int32[]" addrspace(1)* %13
+}
+
+INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
+Successfully read CultureData.get_INEGATIVEPERCENT
+
+define i32 @CultureData.get_INEGATIVEPERCENT(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = icmp ne i32 %2, -1
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
+  store i32 %7, i32 addrspace(1)* %8
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
+  %12 = load i32 addrspace(1)* %11, align 8
+  ret i32 %12
+}
+
+INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
+Successfully read CultureData.DoGetLocaleInfoInt
+
+define i32 @CultureData.DoGetLocaleInfoInt(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp ne i32 %2, 0
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32* %arg1
+  %6 = or i32 %5, -2147483648
+  store i32 %6, i32* %arg1
+  br label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %10 = load %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32* %arg1
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32* %loc0
+  ret i32 %13
+}
+
+INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
+Successfully read CultureData.get_IPOSITIVEPERCENT
+
+define i32 @CultureData.get_IPOSITIVEPERCENT(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = icmp ne i32 %2, -1
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
+  store i32 %7, i32 addrspace(1)* %8
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
+  %12 = load i32 addrspace(1)* %11, align 8
+  ret i32 %12
+}
+
+INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
+Successfully read CultureData.get_SPERCENT
+
+define %System.String addrspace(1)* @CultureData.get_SPERCENT(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
+Successfully read CultureData.get_SPERMILLE
+
+define %System.String addrspace(1)* @CultureData.get_SPERMILLE(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
+Successfully read CultureData.get_SNEGINFINITY
+
+define %System.String addrspace(1)* @CultureData.get_SNEGINFINITY(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
+Successfully read CultureData.get_SPOSINFINITY
+
+define %System.String addrspace(1)* @CultureData.get_SPOSINFINITY(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method CultureData::get_SNAN using LLILCJit
+Successfully read CultureData.get_SNAN
+
+define %System.String addrspace(1)* @CultureData.get_SNAN(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %9, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Globalization.CultureData addrspace(1)** %this
+  %6 = load %System.Globalization.CultureData addrspace(1)** %this
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
+  %8 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %entry, %4
+  %10 = load %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
+  %12 = load %System.String addrspace(1)* addrspace(1)* %11, align 8
+  ret %System.String addrspace(1)* %12
+}
+
+INFO:  jitting method StreamWriter::Write using LLILCJit
+Failed to read StreamWriter.Write[Tail call]
+INFO:  jitting method String::CopyTo using LLILCJit
+Failed to read String.CopyTo[loadElemA]
+INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
+Failed to read ConsoleEncoding.GetPreamble[Tail call]
+INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
+Successfully read EmptyArray`1..cctor
+
+define void @"EmptyArray`1..cctor"() {
+entry:
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %2 = getelementptr inbounds i8 addrspace(1)* %1, i64 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[loadElemA]
+INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
+Failed to read EncoderNLS.GetBytes[Tail call]
+INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
+Failed to read UTF8Encoding.GetBytes[storeElem]
+INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
+Successfully read WindowsConsoleStream.Write
+
+define void @WindowsConsoleStream.Write(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = load %"System.Byte[]" addrspace(1)** %arg1
+  %2 = load i32* %arg2
+  %3 = load i32* %arg3
+  %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
+  %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %7 = load i64 addrspace(1)* %6, align 8
+  %8 = load %"System.Byte[]" addrspace(1)** %arg1
+  %9 = load i32* %arg2
+  %10 = load i32* %arg3
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
+  store i32 %11, i32* %loc0
+  %12 = load i32* %loc0
+  %13 = icmp eq i32 %12, 0
+  br i1 %13, label %17, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = load i32* %loc0
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %entry
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
+Successfully read ConsoleStream.ValidateWrite
+
+define void @ConsoleStream.ValidateWrite(%System.IO.ConsoleStream addrspace(1)* %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32* %arg2
+  %7 = icmp slt i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load i32* %arg3
+  %10 = icmp sge i32 %9, 0
+  br i1 %10, label %22, label %11
+
+; <label>:11                                      ; preds = %5, %8
+  %12 = load i32* %arg2
+  %13 = icmp slt i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %18
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %18
+
+; <label>:18                                      ; preds = %14, %16
+  %19 = phi %System.String addrspace(1)* [ %15, %14 ], [ %17, %16 ]
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %21 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %21, %System.String addrspace(1)* %19, %System.String addrspace(1)* %20)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %21) #0
+  unreachable
+
+; <label>:22                                      ; preds = %8
+  %23 = load %"System.Byte[]" addrspace(1)** %arg1
+  %24 = getelementptr inbounds %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %25 = load i32 addrspace(1)* %24
+  %26 = zext i32 %25 to i64
+  %27 = trunc i64 %26 to i32
+  %28 = load i32* %arg2
+  %29 = sub i32 %27, %28
+  %30 = load i32* %arg3
+  %31 = icmp sge i32 %29, %30
+  br i1 %31, label %35, label %32
+
+; <label>:32                                      ; preds = %22
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %22
+  %36 = load %System.IO.ConsoleStream addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
+  %38 = load i8 addrspace(1)* %37, align 8
+  %39 = zext i8 %38 to i32
+  %40 = icmp ne i32 %39, 0
+  br i1 %40, label %43, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  ret void
+}
+
+INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
+Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
+Failed to read WindowsConsoleStream.Flush[Tail call]
+INFO:  jitting method TextWriter::WriteLine using LLILCJit
+Failed to read TextWriter.WriteLine[Tail call]
+INFO:  jitting method StreamWriter::Write using LLILCJit
+Failed to read StreamWriter.Write[Tail call]
+

--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -724,8 +724,6 @@ function Global:ExcludeTest([string]$Arch="x64", [string]$Build="Release")
   $CoreCLRTestTargetBinaries = CoreCLRTestTargetBinaries -Arch $Arch -Build $Build
   pushd .
   cd $CoreCLRTestTargetBinaries\JIT\CodeGenBringUpTests
-  del DblRem*
-  del FpRem*
   del div2*
   del localloc*
   popd


### PR DESCRIPTION
Pat implemented early helper expansion for some double to int converts a while back, but the tests that show this were disabled.
