### PR TITLE
Reader cleanup.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -812,7 +812,6 @@ public:
   // Call CreateSym for each param and auto. Also return function bytecode
   // start and length.
   void initParamsAndAutos(uint32_t NumParam, uint32_t NumAuto);
-  void handleNonEmptyStack(FlowGraphNode *Fg, IRNode **NewIR, bool *FmbAssign);
 
   // Needed by inlining so public
   FlowGraphNode *buildFlowGraph(FlowGraphNode **FgTail);
@@ -864,7 +863,7 @@ private:
                                              uint32_t BufferSize);
   void fgBuildPhase1(FlowGraphNode *Fg, uint8_t *Buffer, uint32_t BufferSize);
   void fgAttachGlobalVerifyData(FlowGraphNode *HeadBlock);
-  void fgAddArcs(FlowGraphNode *HeadBlock);
+  void fgFixRecursiveEdges(FlowGraphNode *HeadBlock);
   IRNode *fgAddCaseToCaseListHelper(IRNode *SwitchNode, IRNode *LabelNode,
                                     uint32_t Element);
   FlowGraphNodeWorkList *


### PR DESCRIPTION
- Delete handleNonEmptyStack as it's unused. Legacy jit called it from
  maintainOperandStack but we are using a different approach with PHI
  nodes.
- Rename fgAddArc to fgFixRecursiveEdges and delete code that adds
  fall-through arcs. We set those edges in fgSplitBlock.
- Fix comments for fgBuildBasicBlocksFromBytes.

I verified that this is a no-diffs change.
