### PR TITLE
Enable use of Conservative GC for LLILC Testing

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -780,6 +780,7 @@ function Global:RunTest([string]$Arch="x64", [string]$Build="Release")
   $CoreCLRTestAssets = CoreCLRTestAssets
   $CoreCLRRuntime = CoreCLRRuntime
   $CoreCLRVersion = CoreCLRVersion
+  $LLILCTest = LLILCTest
   
   # Workaround exception handling issue
   chcp 65001 | Out-Null
@@ -787,8 +788,7 @@ function Global:RunTest([string]$Arch="x64", [string]$Build="Release")
   $Env:SkipTestAssemblies = "Common;Exceptions;GC;Loader;managed;packages;Regressions;runtime;Tests;TestWrappers_x64_release;Threading" 
   pushd .
   cd $CoreCLRTestAssets\coreclr\tests
-
-  .\runtest $Arch $Build EnableAltJit LLILCJit $CoreCLRRuntime\$CoreCLRVersion\bin | Write-Host
+  .\runtest $Arch $Build TestEnv $LLILCTest\LLILCTestEnv.cmd $CoreCLRRuntime\$CoreCLRVersion\bin | Write-Host
   $NumDiff = CheckDiff -Create $True -UseDiffTool $False -Arch $Arch -Build $Build
   $NumFailures = CheckFailure -Arch $Arch -Build $Build
   popd

--- a/test/LLILCTestEnv.cmd
+++ b/test/LLILCTestEnv.cmd
@@ -1,0 +1,9 @@
+REM -------------------------------------------------------------------------
+REM 
+REM  This script provides LLILC test environment settings
+REM
+REM -------------------------------------------------------------------------
+
+set COMPLUS_AltJit=*
+set COMPLUS_AltJitName=LLILCJit.dll
+set COMPLUS_GCCONSERVATIVE=1


### PR DESCRIPTION
This change has two parts:
(1) Pass ALTJIT settings via the LLILCTestEnv.cmd script, to match
    the change in CoreClr test infrastructure.
(2) Run CoreCLR in Conservative GC mode for LLILC tests.

Testing:
LLILC Tests passed locally

This change fixes Issue# 27
