### PR TITLE
Remove unused context field.

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -56,7 +56,7 @@ struct LLILCJitContext {
   /// values in the IR and these values can vary from run to run, so a bitcode
   /// file saved from a previous run may not work as expected.
   ///
-  /// \param MethodInfo  The EE info for the method being jitted.
+  /// \param MethodInfo  The CoreCLR method info for the method being jitted.
   std::unique_ptr<llvm::Module>
   getModuleForMethod(CORINFO_METHOD_INFO *MethodInfo);
 
@@ -64,9 +64,8 @@ struct LLILCJitContext {
   void outputDebugMethodName();
 
 public:
-  uint8_t *ILCursor;
 
-  /// \name EE information
+  /// \name CoreCLR EE information
   //@{
   ICorJitInfo *JitInfo;              ///< EE callback interface
   CORINFO_METHOD_INFO *MethodInfo;   ///< Description of method to jit
@@ -101,7 +100,7 @@ public:
 ///
 /// The Jit may be invoked concurrently on more than one thread. To avoid 
 /// synchronization overhead it maintains per-thread state, mainly to map from
-/// EE artifacts to LLVM data structures.
+/// CoreCLR EE artifacts to LLVM data structures.
 ///
 /// The per thread state also provides access to the current Jit context in 
 /// case it is ever needed.
@@ -137,9 +136,9 @@ public:
   std::map<CORINFO_FIELD_HANDLE, uint32_t> FieldIndexMap;
 };
 
-/// \brief The Jit interface to the EE.
+/// \brief The Jit interface to the CoreCLR EE.
 ///
-/// This class implements the Jit interface to the EE. The EE uses this
+/// This class implements the Jit interface to the CoreCLR EE. The EE uses this
 /// to direct the jit to jit methods. There is a single instance of this
 /// object in the process, created by the \p getJit() function exported from
 /// the jit library or DLL.

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -138,7 +138,6 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   // Fill in context information from the CLR
   Context.JitInfo = JitInfo;
   Context.MethodInfo = MethodInfo;
-  Context.ILCursor = MethodInfo->ILCode;
   Context.Flags = Flags;
   JitInfo->getEEInfo(&Context.EEInfo);
 


### PR DESCRIPTION
I left off documenting the ILCursor field in the jit context because I'd intended to remove it, but I left it around by accident. This change removes it.

I'm also trying to use "CoreCLR EE" in contexts where one might be confused and think that EE is referring to LLVM's EE.
