### PR TITLE
Remove NewIR insertion point threading

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -359,7 +359,7 @@ public:
   ///
   /// \param NewVal The value to be pushed.
   /// \pre NewVal != NULL
-  virtual void push(IRNode *NewVal, IRNode **NewIR) = 0;
+  virtual void push(IRNode *NewVal) = 0;
 
   /// \brief Make the operand stack empty.
   ///
@@ -485,11 +485,11 @@ public:
   bool getMethodHandleNodeRequiresRuntimeLookup();
   bool getCallTargetNodeRequiresRuntimeLookup();
 
-  IRNode *getMethodHandleNode(IRNode **NewIR);
-  IRNode *getClassHandleNode(IRNode **NewIR);
-  IRNode *getTypeContextNode(IRNode **NewIR);
+  IRNode *getMethodHandleNode();
+  IRNode *getClassHandleNode();
+  IRNode *getTypeContextNode();
 
-  IRNode *applyThisTransform(IRNode *ThisIR, IRNode **NewIR);
+  IRNode *applyThisTransform(IRNode *ThisIR);
 
   bool hasThis() { return HasThisPtr; }
   bool isJmp() { return IsJmp; }
@@ -678,7 +678,6 @@ struct ReadBytesForFlowGraphNodeHelperParam {
   ReaderException *Excep;
   FlowGraphNode *Fg;
   bool IsVerifyOnly;
-  IRNode **NewIR; // Used in a trace pr post process
   uint32_t CurrentOffset;
   bool LocalFault;
   bool HasFallThrough;
@@ -830,7 +829,7 @@ public:
   void initVerifyInfo(void);
 
 private:
-  void setupBlockForEH(IRNode **NewIR);
+  void setupBlockForEH();
 
   bool isOffsetInstrStart(uint32_t Offset);
 
@@ -1006,7 +1005,7 @@ public:
                           void *Param);
 
 protected:
-  void clearStack(IRNode **NewIR);
+  void clearStack();
 
   // Client defined function to initialize verification state.
   void verifyNeedsVerification();
@@ -1207,8 +1206,7 @@ public:
   // ///////////////////////////////////////////////////////////////////////////
 
   IRNode *rdrCall(ReaderCallTargetData *CallTargetData,
-                  ReaderBaseNS::CallOpcode Opcode, IRNode **CallNode,
-                  IRNode **NewIR);
+                  ReaderBaseNS::CallOpcode Opcode, IRNode **CallNode);
 
   void makeReaderCallTargetDataForNewObj(ReaderCallTargetData *CallTargetData,
                                          mdToken TargetToken,
@@ -1262,33 +1260,29 @@ public:
 
 private:
   void rdrMakeCallTargetNode(ReaderCallTargetData *CallTargetData,
-                             IRNode **ThisPointer, IRNode **NewIR);
+                             IRNode **ThisPointer);
 
   IRNode *rdrMakeLdFtnTargetNode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                 CORINFO_CALL_INFO *CallInfo, IRNode **NewIR);
+                                 CORINFO_CALL_INFO *CallInfo);
 
-  IRNode *rdrGetDirectCallTarget(ReaderCallTargetData *CallTargetData,
-                                 IRNode **NewIR);
+  IRNode *rdrGetDirectCallTarget(ReaderCallTargetData *CallTargetData);
 
   IRNode *rdrGetDirectCallTarget(CORINFO_METHOD_HANDLE Method,
                                  mdToken MethodToken, bool NeedsNullCheck,
-                                 bool CanMakeDirectCall, bool &UsesMethodDesc,
-                                 IRNode **NewIR);
+                                 bool CanMakeDirectCall, bool &UsesMethodDesc);
   IRNode *
-  rdrGetCodePointerLookupCallTarget(ReaderCallTargetData *CallTargetData,
-                                    IRNode **NewIR);
+  rdrGetCodePointerLookupCallTarget(ReaderCallTargetData *CallTargetData);
 
   IRNode *rdrGetCodePointerLookupCallTarget(CORINFO_CALL_INFO *CallInfo,
-                                            bool &IsIndirect, IRNode **NewIR);
+                                            bool &IsIndirect);
 
   IRNode *rdrGetIndirectVirtualCallTarget(ReaderCallTargetData *CallTargetData,
-                                          IRNode **ThisPointer, IRNode **NewIR);
+                                          IRNode **ThisPointer);
 
-  IRNode *rdrGetVirtualStubCallTarget(ReaderCallTargetData *CallTargetData,
-                                      IRNode **NewIR);
+  IRNode *rdrGetVirtualStubCallTarget(ReaderCallTargetData *CallTargetData);
 
   IRNode *rdrGetVirtualTableCallTarget(ReaderCallTargetData *CallTargetData,
-                                       IRNode **ThisPointer, IRNode **NewIR);
+                                       IRNode **ThisPointer);
 
   // Delegate invoke and delegate construct optimizations
   bool rdrCallIsDelegateInvoke(ReaderCallTargetData *CallTargetData);
@@ -1296,10 +1290,10 @@ private:
 #ifdef FEATURE_CORECLR
   void rdrInsertCalloutForDelegate(CORINFO_CLASS_HANDLE DelegateType,
                                    CORINFO_METHOD_HANDLE CalleeMethod,
-                                   mdToken MethodToken, IRNode **NewIR);
+                                   mdToken MethodToken);
 #endif // FEATURE_CORECLR
   IRNode *rdrGetDelegateInvokeTarget(ReaderCallTargetData *CallTargetData,
-                                     IRNode **ThisPtr, IRNode **NewIR);
+                                     IRNode **ThisPtr);
 
 public:
   void
@@ -1307,25 +1301,23 @@ public:
                      CorInfoHelpFunc HelperId, bool IsLoad,
                      IRNode *Dst, // dst node if this is a load, otherwise NULL
                      IRNode *Obj, IRNode *Value, ReaderAlignType Alignment,
-                     bool IsVolatile, IRNode **NewIR);
+                     bool IsVolatile);
   void rdrCallWriteBarrierHelper(IRNode *Arg1, IRNode *Arg2,
                                  ReaderAlignType Alignment, bool IsVolatile,
-                                 IRNode **NewIR,
+
                                  CORINFO_RESOLVED_TOKEN *ResolvedToken,
                                  bool IsNonValueClass, bool IsValueIsPointer,
                                  bool IsFieldToken, bool IsUnchecked);
   void rdrCallWriteBarrierHelperForReturnValue(IRNode *Arg1, IRNode *Arg2,
-                                               IRNode **NewIR, mdToken Token);
+                                               mdToken Token);
   IRNode *rdrGetFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
                              CORINFO_FIELD_INFO *FieldInfo, IRNode *Obj,
-                             bool BaseIsGCObj, bool MustNullCheck,
-                             IRNode **NewIR);
+                             bool BaseIsGCObj, bool MustNullCheck);
   IRNode *rdrGetStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                   CORINFO_FIELD_INFO *FieldInfo,
-                                   IRNode **NewIR);
+                                   CORINFO_FIELD_INFO *FieldInfo);
   IRNode *rdrCallGetStaticBase(CORINFO_CLASS_HANDLE Class, mdToken ClassToken,
                                CorInfoHelpFunc HelperId, bool NoCtor,
-                               bool CanMoveUp, IRNode *Dst, IRNode **NewIR);
+                               bool CanMoveUp, IRNode *Dst);
 
 public:
   // //////////////////////////////////////////////////////////////////////////
@@ -1506,13 +1498,11 @@ public:
   bool isPrimitiveType(CORINFO_CLASS_HANDLE Handle);
   static bool isPrimitiveType(CorInfoType CorType);
 
-  void handleClassAccess(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode **NewIR);
+  void handleClassAccess(CORINFO_RESOLVED_TOKEN *ResolvedToken);
   void handleMemberAccess(CorInfoIsAccessAllowedResult AccessAllowed,
-                          const CORINFO_HELPER_DESC &AccessHelper,
-                          IRNode **NewIR);
+                          const CORINFO_HELPER_DESC &AccessHelper);
   void handleMemberAccessWorker(CorInfoIsAccessAllowedResult AccessAllowed,
-                                const CORINFO_HELPER_DESC &AccessHelper,
-                                IRNode **NewIR);
+                                const CORINFO_HELPER_DESC &AccessHelper);
   void
   handleMemberAccessForVerification(CorInfoIsAccessAllowedResult AccessAllowed,
                                     const CORINFO_HELPER_DESC &AccessHelper,
@@ -1522,8 +1512,7 @@ public:
                                     const char *HResult
 #endif // CC_PEVERIFY
                                     );
-  void insertHelperCall(const CORINFO_HELPER_DESC &HelperCallDesc,
-                        IRNode **NewIR);
+  void insertHelperCall(const CORINFO_HELPER_DESC &HelperCallDesc);
   bool canTailCall(CORINFO_METHOD_HANDLE DeclaredTarget,
                    CORINFO_METHOD_HANDLE ExactTarget, bool IsTailPrefix);
   CorInfoInline canInline(CORINFO_METHOD_HANDLE Caller,
@@ -1559,7 +1548,7 @@ public:
                                  CORINFO_SIG_INFO *Sig);
 
   // Get a node that can be passed to the sync method helpers.
-  IRNode *rdrGetCritSect(IRNode **NewIR);
+  IRNode *rdrGetCritSect();
 
   //
   // Support for filtering runtime-thrown exceptions
@@ -1587,50 +1576,46 @@ public:
   // Used for testing, client can force verification.
   virtual bool verForceVerification(void) = 0;
 
-  virtual bool abs(IRNode *Arg1, IRNode **RetVal, IRNode **NewIR) = 0;
+  virtual bool abs(IRNode *Arg1, IRNode **RetVal) = 0;
 
-  virtual IRNode *argList(IRNode **NewIR) = 0;
-  virtual IRNode *instParam(IRNode **NewIR) = 0;
-  virtual IRNode *secretParam(IRNode **NewIR) = 0;
-  virtual IRNode *thisObj(IRNode **NewIR) = 0;
-  virtual void boolBranch(ReaderBaseNS::BoolBranchOpcode Opcode, IRNode *Arg1,
-                          IRNode **NewIR) = 0;
+  virtual IRNode *argList() = 0;
+  virtual IRNode *instParam() = 0;
+  virtual IRNode *secretParam() = 0;
+  virtual IRNode *thisObj() = 0;
+  virtual void boolBranch(ReaderBaseNS::BoolBranchOpcode Opcode,
+                          IRNode *Arg1) = 0;
   virtual IRNode *box(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                      IRNode **NewIR, uint32_t *NextOffset = NULL,
+                      uint32_t *NextOffset = NULL,
                       VerificationState *VState = NULL);
   virtual IRNode *binaryOp(ReaderBaseNS::BinaryOpcode Opcode, IRNode *Arg1,
-                           IRNode *Arg2, IRNode **NewIR) = 0;
-  virtual void branch(IRNode **NewIR) = 0;
-  virtual void breakOpcode(IRNode **NewIR);
+                           IRNode *Arg2) = 0;
+  virtual void branch() = 0;
+  virtual void breakOpcode();
   virtual IRNode *call(ReaderBaseNS::CallOpcode Opcode, mdToken Token,
                        mdToken ConstraintTypeRef, mdToken LoadFtnToken,
                        bool IsReadOnlyPrefix, bool IsTailCallPrefix,
                        bool IsUnmarkedTailCall, uint32_t CurrentOffset,
-                       bool *IsRecursiveTailCall, IRNode **NewIR) = 0;
+                       bool *IsRecursiveTailCall) = 0;
   virtual IRNode *castClass(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                            IRNode *ObjRefNode, IRNode **NewIR);
+                            IRNode *ObjRefNode);
   virtual IRNode *isInst(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                         IRNode *ObjRefNode, IRNode **NewIR);
+                         IRNode *ObjRefNode);
   virtual IRNode *castOp(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                         IRNode *ObjRefNode, IRNode **NewIR,
-                         CorInfoHelpFunc HelperId) = 0;
+                         IRNode *ObjRefNode, CorInfoHelpFunc HelperId) = 0;
 
-  virtual IRNode *ckFinite(IRNode *Arg1, IRNode **NewIR) = 0;
+  virtual IRNode *ckFinite(IRNode *Arg1) = 0;
   virtual IRNode *cmp(ReaderBaseNS::CmpOpcode Opcode, IRNode *Arg1,
-                      IRNode *Arg2, IRNode **NewIR) = 0;
+                      IRNode *Arg2) = 0;
   virtual void condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,
-                          IRNode *Arg2, IRNode **NewIR) = 0;
-  virtual IRNode *conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1,
-                       IRNode **NewIR) = 0;
+                          IRNode *Arg2) = 0;
+  virtual IRNode *conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1) = 0;
   virtual void cpBlk(IRNode *ByteCount, IRNode *SourceAddress,
                      IRNode *DestinationAddress, ReaderAlignType Alignment,
-                     bool IsVolatile, IRNode **NewIR);
+                     bool IsVolatile);
   virtual void cpObj(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                     IRNode *Arg2, ReaderAlignType Alignment, bool IsVolatile,
-                     IRNode **NewIR);
-  virtual void dup(IRNode *Opr, IRNode **Result1, IRNode **Result2,
-                   IRNode **NewIR) = 0;
-  virtual void endFilter(IRNode *Arg1, IRNode **NewIR) = 0;
+                     IRNode *Arg2, ReaderAlignType Alignment, bool IsVolatile);
+  virtual void dup(IRNode *Opr, IRNode **Result1, IRNode **Result2) = 0;
+  virtual void endFilter(IRNode *Arg1) = 0;
 
   virtual FlowGraphNode *fgNodeGetNext(FlowGraphNode *FgNode) = 0;
   virtual uint32_t fgNodeGetStartMSILOffset(FlowGraphNode *Fg) = 0;
@@ -1644,156 +1629,138 @@ public:
   virtual void fgNodeSetOperandStack(FlowGraphNode *Fg, ReaderStack *Stack) = 0;
   virtual ReaderStack *fgNodeGetOperandStack(FlowGraphNode *Fg) = 0;
 
-  virtual IRNode *getStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                        IRNode **NewIR) = 0;
+  virtual IRNode *
+  getStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken) = 0;
   virtual void initBlk(IRNode *NumBytes, IRNode *ValuePerByte,
                        IRNode *DestinationAddress, ReaderAlignType Alignment,
-                       bool IsVolatile, IRNode **NewIR);
-  virtual void initObj(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg2,
-                       IRNode **NewIR);
-  virtual void insertThrow(CorInfoHelpFunc ThrowHelper, uint32_t Offset,
-                           IRNode **NewIR);
+                       bool IsVolatile);
+  virtual void initObj(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg2);
+  virtual void insertThrow(CorInfoHelpFunc ThrowHelper, uint32_t Offset);
   virtual void jmp(ReaderBaseNS::CallOpcode Opcode, mdToken Token, bool HasThis,
-                   bool HasVarArg, IRNode **NewIR) = 0;
+                   bool HasVarArg) = 0;
 
   virtual void leave(uint32_t TargetOffset, bool IsNonLocal,
-                     bool EndsWithNonLocalGoto, IRNode **NewIR) = 0;
-  virtual IRNode *loadArg(uint32_t ArgOrdinal, bool IsJmp, IRNode **NewIR) = 0;
-  virtual IRNode *loadLocal(uint32_t ArgOrdinal, IRNode **NewIR) = 0;
-  virtual IRNode *loadArgAddress(uint32_t ArgOrdinal, IRNode **NewIR) = 0;
-  virtual IRNode *loadLocalAddress(uint32_t LocOrdinal, IRNode **NewIR) = 0;
-  virtual IRNode *loadConstantI4(int32_t Constant, IRNode **NewIR) = 0;
-  virtual IRNode *loadConstantI8(int64_t Constant, IRNode **NewIR) = 0;
-  virtual IRNode *loadConstantI(size_t Constant, IRNode **NewIR) = 0;
-  virtual IRNode *loadConstantR4(float Value, IRNode **NewIR) = 0;
-  virtual IRNode *loadConstantR8(double Value, IRNode **NewIR) = 0;
+                     bool EndsWithNonLocalGoto) = 0;
+  virtual IRNode *loadArg(uint32_t ArgOrdinal, bool IsJmp) = 0;
+  virtual IRNode *loadLocal(uint32_t ArgOrdinal) = 0;
+  virtual IRNode *loadArgAddress(uint32_t ArgOrdinal) = 0;
+  virtual IRNode *loadLocalAddress(uint32_t LocOrdinal) = 0;
+  virtual IRNode *loadConstantI4(int32_t Constant) = 0;
+  virtual IRNode *loadConstantI8(int64_t Constant) = 0;
+  virtual IRNode *loadConstantI(size_t Constant) = 0;
+  virtual IRNode *loadConstantR4(float Value) = 0;
+  virtual IRNode *loadConstantR8(double Value) = 0;
   virtual IRNode *loadElem(ReaderBaseNS::LdElemOpcode Opcode,
                            CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                           IRNode *Arg2, IRNode **NewIR) = 0;
+                           IRNode *Arg2) = 0;
   virtual IRNode *loadElemA(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                            IRNode *Arg2, bool IsReadOnly, IRNode **NewIR) = 0;
+                            IRNode *Arg2, bool IsReadOnly) = 0;
   virtual IRNode *loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                            ReaderAlignType Alignment, bool IsVolatile,
-                            IRNode **NewIR) = 0;
+                            ReaderAlignType Alignment, bool IsVolatile) = 0;
   virtual IRNode *loadIndir(ReaderBaseNS::LdIndirOpcode Opcode, IRNode *Address,
                             ReaderAlignType Alignement, bool IsVolatile,
-                            bool IsInterfReadOnly, IRNode **NewIR);
-  virtual IRNode *loadNull(IRNode **NewIR) = 0;
-  virtual IRNode *localAlloc(IRNode *Arg, bool IsZeroInit, IRNode **NewIR) = 0;
+                            bool IsInterfReadOnly);
+  virtual IRNode *loadNull() = 0;
+  virtual IRNode *localAlloc(IRNode *Arg, bool IsZeroInit) = 0;
   virtual IRNode *loadFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                   IRNode *Obj, IRNode **NewIR) = 0;
-  virtual IRNode *loadLen(IRNode *Arg1, IRNode **NewIR) = 0;
-  virtual bool arrayAddress(CORINFO_SIG_INFO *Aig, IRNode **RetVal,
-                            IRNode **NewIR) = 0;
-  virtual IRNode *loadStringLen(IRNode *Arg1, IRNode **NewIR) = 0;
-  virtual IRNode *getTypeFromHandle(IRNode *Arg1, IRNode **NewIR) = 0;
-  virtual IRNode *getValueFromRuntimeHandle(IRNode *Arg1, IRNode **NewIR) = 0;
+                                   IRNode *Obj) = 0;
+  virtual IRNode *loadLen(IRNode *Arg1) = 0;
+  virtual bool arrayAddress(CORINFO_SIG_INFO *Aig, IRNode **RetVal) = 0;
+  virtual IRNode *loadStringLen(IRNode *Arg1) = 0;
+  virtual IRNode *getTypeFromHandle(IRNode *Arg1) = 0;
+  virtual IRNode *getValueFromRuntimeHandle(IRNode *Arg1) = 0;
   virtual IRNode *arrayGetDimLength(IRNode *Arg1, IRNode *Arg2,
-                                    CORINFO_CALL_INFO *CallInfo,
-                                    IRNode **NewIR) = 0;
+                                    CORINFO_CALL_INFO *CallInfo) = 0;
   virtual IRNode *loadObj(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
                           ReaderAlignType AlignmentPrefix, bool IsVolatile,
-                          bool IsField, IRNode **NewIR);
+                          bool IsField);
   virtual IRNode *loadAndBox(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                             IRNode *Address, ReaderAlignType AlignmentPrefix,
-                             IRNode **NewIR) = 0;
+                             IRNode *Address,
+                             ReaderAlignType AlignmentPrefix) = 0;
   virtual IRNode *convertHandle(IRNode *GetTokenNumeric,
                                 CorInfoHelpFunc HelperID,
-                                CORINFO_CLASS_HANDLE Class, IRNode **NewIR) = 0;
+                                CORINFO_CLASS_HANDLE Class) = 0;
   virtual void
-  convertTypeHandleLookupHelperToIntrinsic(bool CanCompareToGetType,
-                                           IRNode *IR) = 0;
+  convertTypeHandleLookupHelperToIntrinsic(bool CanCompareToGetType) = 0;
 
   virtual IRNode *loadStaticField(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                  bool IsVolatile, IRNode **NewIR) = 0;
-  virtual IRNode *loadStr(mdToken Token, IRNode **NewIR) = 0;
-  virtual IRNode *loadToken(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                            IRNode **NewIR);
+                                  bool IsVolatile) = 0;
+  virtual IRNode *loadStr(mdToken Token) = 0;
+  virtual IRNode *loadToken(CORINFO_RESOLVED_TOKEN *ResolvedToken);
   virtual IRNode *loadVirtFunc(IRNode *Arg1,
                                CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                               CORINFO_CALL_INFO *CallInfo, IRNode **NewIR) = 0;
+                               CORINFO_CALL_INFO *CallInfo) = 0;
   virtual IRNode *loadPrimitiveType(IRNode *Address, CorInfoType CorType,
                                     ReaderAlignType Slignment, bool IsVolatile,
-                                    bool IsInterfConst, IRNode **NewIR) = 0;
+                                    bool IsInterfConst) = 0;
   virtual IRNode *loadNonPrimitiveObj(IRNode *Address,
                                       CORINFO_CLASS_HANDLE Class,
                                       ReaderAlignType Alignment,
-                                      bool IsVolatile, IRNode **NewIR) = 0;
+                                      bool IsVolatile) = 0;
   virtual IRNode *makeRefAny(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                             IRNode *Object, IRNode **NewIR) = 0;
-  virtual IRNode *newArr(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                         IRNode **NewIR) = 0;
+                             IRNode *Object) = 0;
+  virtual IRNode *newArr(CORINFO_RESOLVED_TOKEN *ResolvedToken,
+                         IRNode *Arg1) = 0;
   virtual IRNode *newObj(mdToken Token, mdToken LoadFtnToken,
-                         uint32_t CurrentOffset, IRNode **NewIR) = 0;
-  virtual void pop(IRNode *Opr, IRNode **NewIR) = 0;
-  virtual IRNode *refAnyType(IRNode *Arg1, IRNode **NewIR) = 0;
-  virtual IRNode *refAnyVal(IRNode *Val, CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                            IRNode **NewIR);
-  virtual void rethrow(IRNode **NewIR) = 0;
-  virtual void returnOpcode(IRNode *Opr, bool IsSynchronousMethod,
-                            IRNode **NewIR) = 0;
+                         uint32_t CurrentOffset) = 0;
+  virtual void pop(IRNode *Opr) = 0;
+  virtual IRNode *refAnyType(IRNode *Arg1) = 0;
+  virtual IRNode *refAnyVal(IRNode *Val, CORINFO_RESOLVED_TOKEN *ResolvedToken);
+  virtual void rethrow() = 0;
+  virtual void returnOpcode(IRNode *Opr, bool IsSynchronousMethod) = 0;
   virtual IRNode *shift(ReaderBaseNS::ShiftOpcode Opcode, IRNode *ShiftAmount,
-                        IRNode *ShiftOperand, IRNode **NewIR) = 0;
-  virtual IRNode *sizeofOpcode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                               IRNode **NewIR) = 0;
+                        IRNode *ShiftOperand) = 0;
+  virtual IRNode *sizeofOpcode(CORINFO_RESOLVED_TOKEN *ResolvedToken) = 0;
   virtual void storeArg(uint32_t LocOrdinal, IRNode *Arg1,
-                        ReaderAlignType Alignment, bool IsVolatile,
-                        IRNode **NewIR) = 0;
+                        ReaderAlignType Alignment, bool IsVolatile) = 0;
   virtual void storeElem(ReaderBaseNS::StElemOpcode Opcode,
                          CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                         IRNode *Arg2, IRNode *Arg3, IRNode **NewIR) = 0;
-  virtual void storeElemRefAny(IRNode *Value, IRNode *Index, IRNode *Obj,
-                               IRNode **NewIR);
+                         IRNode *Arg2, IRNode *Arg3) = 0;
+  virtual void storeElemRefAny(IRNode *Value, IRNode *Index, IRNode *Obj);
   virtual void storeField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
                           IRNode *Arg2, ReaderAlignType Alignment,
-                          bool IsVolatile, IRNode **NewIR) = 0;
+                          bool IsVolatile) = 0;
   virtual void storeIndir(ReaderBaseNS::StIndirOpcode Opcode, IRNode *Arg1,
                           IRNode *Arg2, ReaderAlignType Alignment,
-                          bool IsVolatile, IRNode **NewIR);
+                          bool IsVolatile);
   virtual void storePrimitiveType(IRNode *Value, IRNode *Address,
                                   CorInfoType CorType,
-                                  ReaderAlignType Alignment, bool IsVolatile,
-                                  IRNode **NewIR) = 0;
+                                  ReaderAlignType Alignment,
+                                  bool IsVolatile) = 0;
   virtual void storeLocal(uint32_t LocOrdinal, IRNode *Arg1,
-                          ReaderAlignType Alignment, bool IsVolatile,
-                          IRNode **NewIR) = 0;
+                          ReaderAlignType Alignment, bool IsVolatile) = 0;
   virtual void storeObj(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
                         IRNode *Arg2, ReaderAlignType Alignment,
-                        bool IsVolatile, bool IsField, IRNode **NewIR);
+                        bool IsVolatile, bool IsField);
   virtual void storeStaticField(CORINFO_RESOLVED_TOKEN *FieldToken,
-                                IRNode *ValueToStore, bool IsVolatile,
-                                IRNode **NewIR) = 0;
-  virtual IRNode *stringGetChar(IRNode *Arg1, IRNode *Arg2, IRNode **NewIR) = 0;
-  virtual bool sqrt(IRNode *Arg1, IRNode **RetVal, IRNode **NewIR) = 0;
+                                IRNode *ValueToStore, bool IsVolatile) = 0;
+  virtual IRNode *stringGetChar(IRNode *Arg1, IRNode *Arg2) = 0;
+  virtual bool sqrt(IRNode *Arg1, IRNode **RetVal) = 0;
 
   virtual bool interlockedIntrinsicBinOp(IRNode *Arg1, IRNode *Arg2,
                                          IRNode **RetVal,
-                                         CorInfoIntrinsics IntrinsicID,
-                                         IRNode **NewIR) = 0;
+                                         CorInfoIntrinsics IntrinsicID) = 0;
   virtual bool interlockedCmpXchg(IRNode *Arg1, IRNode *Arg2, IRNode *Arg3,
                                   IRNode **RetVal,
-                                  CorInfoIntrinsics IntrinsicID,
-                                  IRNode **NewIR) = 0;
-  virtual bool memoryBarrier(IRNode **NewIR) = 0;
-  virtual void switchOpcode(IRNode *Opr, IRNode **NewIR) = 0;
-  virtual void throwOpcode(IRNode *Arg1, IRNode **NewIR) = 0;
-  virtual IRNode *unaryOp(ReaderBaseNS::UnaryOpcode Opcode, IRNode *Arg1,
-                          IRNode **NewIR) = 0;
+                                  CorInfoIntrinsics IntrinsicID) = 0;
+  virtual bool memoryBarrier() = 0;
+  virtual void switchOpcode(IRNode *Opr) = 0;
+  virtual void throwOpcode(IRNode *Arg1) = 0;
+  virtual IRNode *unaryOp(ReaderBaseNS::UnaryOpcode Opcode, IRNode *Arg1) = 0;
   virtual IRNode *unbox(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg2,
-                        IRNode **NewIR, bool AndLoad, ReaderAlignType Alignment,
+                        bool AndLoad, ReaderAlignType Alignment,
                         bool IsVolatile) = 0;
 
   virtual IRNode *unboxAny(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                           ReaderAlignType Alignment, bool IsVolatilePrefix,
-                           IRNode **NewIR);
-  virtual void nop(IRNode **NewIR) = 0;
+                           ReaderAlignType Alignment, bool IsVolatilePrefix);
+  virtual void nop() = 0;
 
   virtual void insertIBCAnnotations() = 0;
   virtual IRNode *insertIBCAnnotation(FlowGraphNode *Node, uint32_t Count,
                                       uint32_t Offset) = 0;
 
   // Insert class constructor
-  virtual void insertClassConstructor(IRNode **NewIR);
+  virtual void insertClassConstructor();
 
   //
   // REQUIRED Client Helper Routines.
@@ -1822,26 +1789,22 @@ public:
   virtual void beginFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrentOffset,
                                   bool IsVerifyOnly) = 0;
   // Called at the end of block processing.
-  virtual void endFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrentOffset,
-                                IRNode **NewIR) = 0;
+  virtual void endFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrentOffset) = 0;
 
   // Used to maintain operand stack.
   virtual void maintainOperandStack(IRNode **Opr1, IRNode **Opr2,
-                                    FlowGraphNode *CurrentBlock,
-                                    IRNode **NewIR) = 0;
+                                    FlowGraphNode *CurrentBlock) = 0;
   virtual void assignToSuccessorStackNode(FlowGraphNode *, IRNode *Destination,
-                                          IRNode *Source, IRNode **NewIR,
-                                          bool *) = 0;
+                                          IRNode *Source, bool *) = 0;
   virtual bool typesCompatible(IRNode *Src1, IRNode *Src2) = 0;
 
-  virtual void removeStackInterference(IRNode **NewIR) = 0;
+  virtual void removeStackInterference() = 0;
 
   virtual void removeStackInterferenceForLocalStore(uint32_t Opcode,
-                                                    uint32_t Ordinal,
-                                                    IRNode **NewIR) = 0;
+                                                    uint32_t Ordinal) = 0;
 
   // Remove all IRNodes from block (for verification error processing.)
-  virtual void clearCurrentBlock(IRNode **NewIR) = 0;
+  virtual void clearCurrentBlock() = 0;
 
   // Called when an assert occurs (debug only)
   static void debugError(const char *Filename, uint32_t LineNumber,
@@ -1954,14 +1917,14 @@ public:
   // after the region.
   virtual IRNode *findTryRegionEndOfClauses(EHRegion *TryRegion) = 0;
 
-  virtual bool isCall(IRNode **NewIR) = 0;
+  virtual bool isCall() = 0;
   virtual bool isRegionStartBlock(FlowGraphNode *Fg) = 0;
   virtual bool isRegionEndBlock(FlowGraphNode *Fg) = 0;
 
   // Create a symbol node that will be used to represent the stack-incoming
   // exception object
   // upon entry to funclets.
-  virtual IRNode *makeExceptionObject(IRNode **NewIR) = 0;
+  virtual IRNode *makeExceptionObject() = 0;
 
   // //////////////////////////////////////////////////////////////////////////
   // Client Supplied Helper Routines, required by VOS support
@@ -1970,58 +1933,54 @@ public:
   // Asks GenIR to make operand value accessible by address, and return a node
   // that references
   // the incoming operand by address.
-  virtual IRNode *addressOfLeaf(IRNode *Leaf, IRNode **NewIR) = 0;
-  virtual IRNode *addressOfValue(IRNode *Leaf, IRNode **NewIR) = 0;
+  virtual IRNode *addressOfLeaf(IRNode *Leaf) = 0;
+  virtual IRNode *addressOfValue(IRNode *Leaf) = 0;
 
   // Helper callback used by rdrCall to emit call code.
   virtual IRNode *genCall(ReaderCallTargetData *CallTargetDaTA,
                           CallArgTriple *Args, uint32_t NumArgs,
-                          IRNode **CallNode, IRNode **NewIR) = 0;
+                          IRNode **CallNode) = 0;
 
   virtual bool canMakeDirectCall(ReaderCallTargetData *CallTargetData) = 0;
 
   // Generate call to helper
   virtual IRNode *callHelper(CorInfoHelpFunc HelperID, IRNode *Dst,
-                             IRNode **NewIR, IRNode *Arg1 = NULL,
-                             IRNode *Arg2 = NULL, IRNode *Arg3 = NULL,
-                             IRNode *Arg4 = NULL,
+                             IRNode *Arg1 = NULL, IRNode *Arg2 = NULL,
+                             IRNode *Arg3 = NULL, IRNode *Arg4 = NULL,
                              ReaderAlignType Alignment = Reader_AlignUnknown,
                              bool IsVolatile = false, bool NoCtor = false,
                              bool CanMoveUp = false) = 0;
 
   // Generate special generics helper that might need to insert flow
   virtual IRNode *callRuntimeHandleHelper(CorInfoHelpFunc Helper, IRNode *Arg1,
-                                          IRNode *Arg2, IRNode *NullCheckArg,
-                                          IRNode **NewIR) = 0;
+                                          IRNode *Arg2,
+                                          IRNode *NullCheckArg) = 0;
 
   virtual IRNode *convertToHelperArgumentType(IRNode *Opr,
-                                              uint32_t DestinationSize,
-                                              IRNode **NewIR) = 0;
+                                              uint32_t DestinationSize) = 0;
 
-  virtual IRNode *genNullCheck(IRNode *Node, IRNode **NewIR) = 0;
+  virtual IRNode *genNullCheck(IRNode *Node) = 0;
 
   virtual void
   createSym(uint32_t Num, bool IsAuto, CorInfoType CorType,
             CORINFO_CLASS_HANDLE Class, bool IsPinned,
             ReaderSpecialSymbolType Type = Reader_NotSpecialSymbol) = 0;
 
-  virtual IRNode *derefAddress(IRNode *Address, bool DestIsGCPtr, bool IsConst,
-                               IRNode **NewIR) = 0;
+  virtual IRNode *derefAddress(IRNode *Address, bool DestIsGCPtr,
+                               bool IsConst) = 0;
 
-  virtual IRNode *conditionalDerefAddress(IRNode *Address, IRNode **NewIR) = 0;
+  virtual IRNode *conditionalDerefAddress(IRNode *Address) = 0;
 
-  virtual IRNode *getHelperCallAddress(CorInfoHelpFunc HelperId,
-                                       IRNode **NewIR) = 0;
+  virtual IRNode *getHelperCallAddress(CorInfoHelpFunc HelperId) = 0;
 
   virtual IRNode *simpleFieldAddress(IRNode *BaseAddress,
                                      CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                     CORINFO_FIELD_INFO *FieldInfo,
-                                     IRNode **NewIR) = 0;
+                                     CORINFO_FIELD_INFO *FieldInfo) = 0;
 
   virtual IRNode *handleToIRNode(mdToken Token, void *EmbedHandle,
                                  void *RealHandle, bool IsIndirect,
                                  bool IsReadOnly, bool IsRelocatable,
-                                 bool IsCallTarget, IRNode **NewIR,
+                                 bool IsCallTarget,
                                  bool IsFrozenObject = false) = 0;
 
   // Create an operand that will be used to hold a pointer.
@@ -2040,31 +1999,27 @@ public:
                          EHRegionList *EhRegionList) = 0;
 
   // Line number info
-  virtual void sequencePoint(int32_t Offset, ReaderBaseNS::OPCODE PrevOp,
-                             IRNode **NewIR);
-  virtual void setSequencePoint(uint32_t, ICorDebugInfo::SourceTypes,
-                                IRNode **NewIR) = 0;
+  virtual void sequencePoint(int32_t Offset, ReaderBaseNS::OPCODE PrevOp);
+  virtual void setSequencePoint(uint32_t, ICorDebugInfo::SourceTypes) = 0;
   virtual bool needSequencePoints() = 0;
 
   // Used to turn token into handle/IRNode
   virtual IRNode *
-  genericTokenToNode(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode **NewIR,
+  genericTokenToNode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
                      bool EmbedParent = false, bool MustRestoreHandle = false,
                      CORINFO_GENERIC_HANDLE *StaticHandle = NULL,
                      bool *IsRuntimeLookup = NULL, bool NeedsResult = true);
 
   virtual IRNode *runtimeLookupToNode(CORINFO_RUNTIME_LOOKUP_KIND Kind,
-                                      CORINFO_RUNTIME_LOOKUP *Lookup,
-                                      IRNode **NewIR);
+                                      CORINFO_RUNTIME_LOOKUP *Lookup);
 
   // Used to expand multidimensional array access intrinsics
-  virtual bool arrayGet(CORINFO_SIG_INFO *Sig, IRNode **RetVal,
-                        IRNode **NewIR) = 0;
-  virtual bool arraySet(CORINFO_SIG_INFO *Sig, IRNode **NewIR) = 0;
+  virtual bool arrayGet(CORINFO_SIG_INFO *Sig, IRNode **RetVal) = 0;
+  virtual bool arraySet(CORINFO_SIG_INFO *Sig) = 0;
 
 #if !defined(NDEBUG)
   virtual void dbDumpFunction(void) = 0;
-  virtual void dbPrintIRNode(IRNode *NewIR) = 0;
+  virtual void dbPrintIRNode(IRNode *Instr) = 0;
   virtual void dbPrintFGNode(FlowGraphNode *Fg) = 0;
   virtual void dbPrintEHRegion(EHRegion *Eh) = 0;
   virtual uint32_t dbGetFuncHash(void) = 0;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -207,7 +207,7 @@ public:
   ///
   /// \param NewVal The value to be pushed.
   /// \pre NewVal != NULL
-  void push(IRNode *NewVal, IRNode **NewIR) override;
+  void push(IRNode *NewVal) override;
 
   /// \brief If the stack is not empty, cause an assertion failure.
   void assertEmpty() override;
@@ -262,47 +262,44 @@ public:
   // Used for testing, client can force verification.
   bool verForceVerification(void) override { return false; };
 
-  bool abs(IRNode *Arg1, IRNode **RetVal, IRNode **NewIR) override {
+  bool abs(IRNode *Arg1, IRNode **RetVal) override {
     throw NotYetImplementedException("abs");
   };
 
-  IRNode *argList(IRNode **NewIR) override;
-  IRNode *instParam(IRNode **NewIR) override;
+  IRNode *argList() override;
+  IRNode *instParam() override;
 
-  IRNode *secretParam(IRNode **NewIR) override {
+  IRNode *secretParam() override {
     throw NotYetImplementedException("secretParam");
   };
-  IRNode *thisObj(IRNode **NewIR) override;
+  IRNode *thisObj() override;
 
-  void boolBranch(ReaderBaseNS::BoolBranchOpcode Opcode, IRNode *Arg1,
-                  IRNode **NewIR) override;
+  void boolBranch(ReaderBaseNS::BoolBranchOpcode Opcode, IRNode *Arg1) override;
 
   IRNode *binaryOp(ReaderBaseNS::BinaryOpcode Opcode, IRNode *Arg1,
-                   IRNode *Arg2, IRNode **NewIR) override;
-  void branch(IRNode **NewIR) override;
+                   IRNode *Arg2) override;
+  void branch() override;
 
   IRNode *call(ReaderBaseNS::CallOpcode Opcode, mdToken Token,
                mdToken ConstraintTypeRef, mdToken LoadFtnToken,
                bool HasReadOnlyPrefix, bool HasTailCallPrefix,
                bool IsUnmarkedTailCall, uint32_t CurrOffset,
-               bool *RecursiveTailCall, IRNode **NewIR) override;
+               bool *RecursiveTailCall) override;
 
   IRNode *castOp(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *ObjRefNode,
-                 IRNode **NewIR, CorInfoHelpFunc HelperId) override;
+                 CorInfoHelpFunc HelperId) override;
 
-  IRNode *ckFinite(IRNode *Arg1, IRNode **NewIR) override {
+  IRNode *ckFinite(IRNode *Arg1) override {
     throw NotYetImplementedException("ckFinite");
   };
-  IRNode *cmp(ReaderBaseNS::CmpOpcode Opode, IRNode *Arg1, IRNode *Arg2,
-              IRNode **NewIR) override;
+  IRNode *cmp(ReaderBaseNS::CmpOpcode Opode, IRNode *Arg1,
+              IRNode *Arg2) override;
   void condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,
-                  IRNode *Arg2, IRNode **NewIR) override;
-  IRNode *conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1,
-               IRNode **NewIR) override;
+                  IRNode *Arg2) override;
+  IRNode *conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1) override;
 
-  void dup(IRNode *Opr, IRNode **Result1, IRNode **Result2,
-           IRNode **NewIR) override;
-  void endFilter(IRNode *Arg1, IRNode **NewIR) override {
+  void dup(IRNode *Opr, IRNode **Result1, IRNode **Result2) override;
+  void endFilter(IRNode *Arg1) override {
     throw NotYetImplementedException("endFilter");
   };
 
@@ -319,177 +316,160 @@ public:
   void fgNodeSetOperandStack(FlowGraphNode *Fg, ReaderStack *Stack) override;
   ReaderStack *fgNodeGetOperandStack(FlowGraphNode *Fg) override;
 
-  IRNode *getStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                IRNode **NewIR) override;
+  IRNode *getStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken) override;
 
   void jmp(ReaderBaseNS::CallOpcode Opcode, mdToken Token, bool HasThis,
-           bool HasVarArg, IRNode **NewIR) override {
+           bool HasVarArg) override {
     throw NotYetImplementedException("jmp");
   };
 
   void leave(uint32_t TargetOffset, bool IsNonLocal,
-             bool EndsWithNonLocalGoto, IRNode **NewIR) override;
-  IRNode *loadArg(uint32_t ArgOrdinal, bool IsJmp, IRNode **NewIR) override;
-  IRNode *loadLocal(uint32_t ArgOrdinal, IRNode **NewIR) override;
-  IRNode *loadArgAddress(uint32_t ArgOrdinal, IRNode **NewIR) override;
-  IRNode *loadLocalAddress(uint32_t LocOrdinal, IRNode **NewIR) override;
-  IRNode *loadConstantI4(int32_t Constant, IRNode **NewIR) override;
-  IRNode *loadConstantI8(int64_t Constant, IRNode **NewIR) override;
-  IRNode *loadConstantI(size_t Constant, IRNode **NewIR) override;
-  IRNode *loadConstantR4(float Value, IRNode **NewIR) override;
-  IRNode *loadConstantR8(double Value, IRNode **NewIR) override;
+             bool EndsWithNonLocalGoto) override;
+  IRNode *loadArg(uint32_t ArgOrdinal, bool IsJmp) override;
+  IRNode *loadLocal(uint32_t ArgOrdinal) override;
+  IRNode *loadArgAddress(uint32_t ArgOrdinal) override;
+  IRNode *loadLocalAddress(uint32_t LocOrdinal) override;
+  IRNode *loadConstantI4(int32_t Constant) override;
+  IRNode *loadConstantI8(int64_t Constant) override;
+  IRNode *loadConstantI(size_t Constant) override;
+  IRNode *loadConstantR4(float Value) override;
+  IRNode *loadConstantR8(double Value) override;
   IRNode *loadElem(ReaderBaseNS::LdElemOpcode Opcode,
                    CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                   IRNode *Arg2, IRNode **NewIR) override {
+                   IRNode *Arg2) override {
     throw NotYetImplementedException("loadElem");
   };
   IRNode *loadElemA(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                    IRNode *Arg2, bool IsReadOnly, IRNode **NewIR) override {
+                    IRNode *Arg2, bool IsReadOnly) override {
     throw NotYetImplementedException("loadElemA");
   };
   IRNode *loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                    ReaderAlignType Alignment, bool IsVolatile,
-                    IRNode **NewIR) override;
+                    ReaderAlignType Alignment, bool IsVolatile) override;
 
-  IRNode *loadNull(IRNode **NewIR) override;
-  IRNode *localAlloc(IRNode *Arg, bool ZeroInit, IRNode **NewIR) override {
+  IRNode *loadNull() override;
+  IRNode *localAlloc(IRNode *Arg, bool ZeroInit) override {
     throw NotYetImplementedException("localAlloc");
   };
-  IRNode *loadFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Obj,
-                           IRNode **NewIR) override;
+  IRNode *loadFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
+                           IRNode *Obj) override;
 
-  IRNode *loadLen(IRNode *Arg1, IRNode **NewIR) override;
+  IRNode *loadLen(IRNode *Arg1) override;
 
-  bool arrayAddress(CORINFO_SIG_INFO *Sig, IRNode **RetVal,
-                    IRNode **NewIR) override {
+  bool arrayAddress(CORINFO_SIG_INFO *Sig, IRNode **RetVal) override {
     throw NotYetImplementedException("arrayAddress");
   };
-  IRNode *loadStringLen(IRNode *Arg1, IRNode **NewIR) override;
+  IRNode *loadStringLen(IRNode *Arg1) override;
 
-  IRNode *getTypeFromHandle(IRNode *Arg1, IRNode **NewIR) override {
+  IRNode *getTypeFromHandle(IRNode *Arg1) override {
     throw NotYetImplementedException("getTypeFromHandle");
   };
-  IRNode *getValueFromRuntimeHandle(IRNode *Arg1, IRNode **NewIR) override {
+  IRNode *getValueFromRuntimeHandle(IRNode *Arg1) override {
     throw NotYetImplementedException("getValueFromRuntimeHandle");
   };
   IRNode *arrayGetDimLength(IRNode *Arg1, IRNode *Arg2,
-                            CORINFO_CALL_INFO *CallInfo,
-                            IRNode **NewIR) override {
+                            CORINFO_CALL_INFO *CallInfo) override {
     throw NotYetImplementedException("arrayGetDimLength");
   };
 
   IRNode *loadAndBox(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Addr,
-                     ReaderAlignType AlignmentPrefix, IRNode **NewIR) override {
+                     ReaderAlignType AlignmentPrefix) override {
     throw NotYetImplementedException("loadAndBox");
   };
   IRNode *convertHandle(IRNode *GetTokenNumericNode, CorInfoHelpFunc HelperID,
-                        CORINFO_CLASS_HANDLE ClassHandle,
-                        IRNode **NewIR) override {
+                        CORINFO_CLASS_HANDLE ClassHandle) override {
     throw NotYetImplementedException("convertHandle");
   };
-  void convertTypeHandleLookupHelperToIntrinsic(bool CanCompareToGetType,
-                                                IRNode *IR) override {
+  void
+  convertTypeHandleLookupHelperToIntrinsic(bool CanCompareToGetType) override {
     throw NotYetImplementedException(
         "convertTypeHandleLookupHelperToIntrinsic");
   };
 
-  IRNode *loadStaticField(CORINFO_RESOLVED_TOKEN *FieldToken, bool IsVolatile,
-                          IRNode **NewIR) override;
+  IRNode *loadStaticField(CORINFO_RESOLVED_TOKEN *FieldToken,
+                          bool IsVolatile) override;
 
-  IRNode *stringLiteral(mdToken Token, void *StringHandle, InfoAccessType Iat,
-                        IRNode **NewIR);
+  IRNode *stringLiteral(mdToken Token, void *StringHandle, InfoAccessType Iat);
 
-  IRNode *loadStr(mdToken Token, IRNode **NewIR) override;
+  IRNode *loadStr(mdToken Token) override;
 
   IRNode *loadVirtFunc(IRNode *Arg1, CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                       CORINFO_CALL_INFO *CallInfo, IRNode **NewIR) override;
+                       CORINFO_CALL_INFO *CallInfo) override;
 
   IRNode *loadPrimitiveType(IRNode *Addr, CorInfoType CorInfoType,
                             ReaderAlignType Alignment, bool IsVolatile,
-                            bool IsInterfConst, IRNode **NewIR) override;
+                            bool IsInterfConst) override;
 
   IRNode *loadNonPrimitiveObj(IRNode *Addr, CORINFO_CLASS_HANDLE ClassHandle,
-                              ReaderAlignType Alignment, bool IsVolatile,
-                              IRNode **NewIR) override {
+                              ReaderAlignType Alignment,
+                              bool IsVolatile) override {
     throw NotYetImplementedException("loadNonPrimitiveObj");
   };
-  IRNode *makeRefAny(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Object,
-                     IRNode **NewIR) override {
+  IRNode *makeRefAny(CORINFO_RESOLVED_TOKEN *ResolvedToken,
+                     IRNode *Object) override {
     throw NotYetImplementedException("makeRefAny");
   };
-  IRNode *newArr(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                 IRNode **NewIR) override;
-  IRNode *newObj(mdToken Token, mdToken LoadFtnToken, uint32_t CurrOffset,
-                 IRNode **NewIR) override;
-  void pop(IRNode *Opr, IRNode **NewIR) override;
-  IRNode *refAnyType(IRNode *Arg1, IRNode **NewIR) override {
+  IRNode *newArr(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1) override;
+  IRNode *newObj(mdToken Token, mdToken LoadFtnToken,
+                 uint32_t CurrOffset) override;
+  void pop(IRNode *Opr) override;
+  IRNode *refAnyType(IRNode *Arg1) override {
     throw NotYetImplementedException("refAnyType");
   };
 
-  void rethrow(IRNode **NewIR) override {
-    throw NotYetImplementedException("rethrow");
-  };
-  void returnOpcode(IRNode *Opr, bool SynchronousMethod,
-                    IRNode **NewIR) override;
+  void rethrow() override { throw NotYetImplementedException("rethrow"); };
+  void returnOpcode(IRNode *Opr, bool SynchronousMethod) override;
   IRNode *shift(ReaderBaseNS::ShiftOpcode Opcode, IRNode *ShiftAmount,
-                IRNode *ShiftOperand, IRNode **NewIR) override;
-  IRNode *sizeofOpcode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                       IRNode **NewIR) override;
-  void storeArg(uint32_t ArgOrdinal, IRNode *Arg1,
-                ReaderAlignType Alignment, bool IsVolatile,
-                IRNode **NewIR) override;
+                IRNode *ShiftOperand) override;
+  IRNode *sizeofOpcode(CORINFO_RESOLVED_TOKEN *ResolvedToken) override;
+  void storeArg(uint32_t ArgOrdinal, IRNode *Arg1, ReaderAlignType Alignment,
+                bool IsVolatile) override;
   void storeElem(ReaderBaseNS::StElemOpcode Opcode,
                  CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                 IRNode *Arg2, IRNode *Arg3, IRNode **NewIR) override {
+                 IRNode *Arg2, IRNode *Arg3) override {
     throw NotYetImplementedException("storeElem");
   };
 
   void storeField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                  IRNode *Arg2, ReaderAlignType Alignment, bool IsVolatile,
-                  IRNode **NewIR) override;
+                  IRNode *Arg2, ReaderAlignType Alignment,
+                  bool IsVolatile) override;
 
   void storePrimitiveType(IRNode *Value, IRNode *Addr, CorInfoType CorInfoType,
-                          ReaderAlignType Alignment, bool IsVolatile,
-                          IRNode **NewIR) override;
+                          ReaderAlignType Alignment, bool IsVolatile) override;
 
-  void storeLocal(uint32_t LocOrdinal, IRNode *Arg1,
-                  ReaderAlignType Alignment, bool IsVolatile,
-                  IRNode **NewIR) override;
+  void storeLocal(uint32_t LocOrdinal, IRNode *Arg1, ReaderAlignType Alignment,
+                  bool IsVolatile) override;
   void storeStaticField(CORINFO_RESOLVED_TOKEN *FieldToken,
-                        IRNode *ValueToStore,
-                        bool IsVolatile, IRNode **NewIR) override;
+                        IRNode *ValueToStore, bool IsVolatile) override;
 
-  IRNode *stringGetChar(IRNode *Arg1, IRNode *Arg2, IRNode **NewIR) override;
+  IRNode *stringGetChar(IRNode *Arg1, IRNode *Arg2) override;
 
-  bool sqrt(IRNode *Arg1, IRNode **RetVal, IRNode **NewIR) override {
+  bool sqrt(IRNode *Arg1, IRNode **RetVal) override {
     throw NotYetImplementedException("sqrt");
   };
 
   // The callTarget node is only required on IA64.
   bool interlockedIntrinsicBinOp(IRNode *Arg1, IRNode *Arg2, IRNode **RetVal,
-                                 CorInfoIntrinsics IntrinsicID,
-                                 IRNode **NewIR) override {
+                                 CorInfoIntrinsics IntrinsicID) override {
     throw NotYetImplementedException("interlockedIntrinsicBinOp");
   };
   bool interlockedCmpXchg(IRNode *Arg1, IRNode *Arg2, IRNode *Arg3,
-                          IRNode **RetVal, CorInfoIntrinsics IntrinsicID,
-                          IRNode **NewIR) override {
+                          IRNode **RetVal,
+                          CorInfoIntrinsics IntrinsicID) override {
     throw NotYetImplementedException("interlockedCmpXchg");
   };
-  bool memoryBarrier(IRNode **NewIR) override;
+  bool memoryBarrier() override;
 
-  void switchOpcode(IRNode *Opr, IRNode **NewIR) override;
+  void switchOpcode(IRNode *Opr) override;
 
-  void throwOpcode(IRNode *Arg1, IRNode **NewIR) override;
-  IRNode *unaryOp(ReaderBaseNS::UnaryOpcode Opcode, IRNode *Arg1,
-                  IRNode **NewIR) override;
+  void throwOpcode(IRNode *Arg1) override;
+  IRNode *unaryOp(ReaderBaseNS::UnaryOpcode Opcode, IRNode *Arg1) override;
   IRNode *unbox(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg2,
-                IRNode **NewIR, bool AndLoad, ReaderAlignType Alignment,
+                bool AndLoad, ReaderAlignType Alignment,
                 bool IsVolatile) override {
     throw NotYetImplementedException("unbox");
   };
 
-  void nop(IRNode **NewIR) override;
+  void nop() override;
 
   void insertIBCAnnotations() override;
   IRNode *insertIBCAnnotation(FlowGraphNode *Node, uint32_t Count,
@@ -526,15 +506,13 @@ public:
   void beginFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrOffset,
                           bool IsVerifyOnly) override;
   // Called at the end of block processing.
-  void endFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrOffset,
-                        IRNode **NewIR) override;
+  void endFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrOffset) override;
 
   // Used to maintain operand stack.
   void maintainOperandStack(IRNode **Opr1, IRNode **Opr2,
-                            FlowGraphNode *CurrentBlock,
-                            IRNode **NewIR) override;
+                            FlowGraphNode *CurrentBlock) override;
   void assignToSuccessorStackNode(FlowGraphNode *, IRNode *Dst, IRNode *Src,
-                                  IRNode **NewIR,
+
                                   bool *IsMultiByteAssign) override {
     throw NotYetImplementedException("assignToSuccessorStackNode");
   };
@@ -542,14 +520,13 @@ public:
     throw NotYetImplementedException("typesCompatible");
   };
 
-  void removeStackInterference(IRNode **NewIR) override;
+  void removeStackInterference() override;
 
   void removeStackInterferenceForLocalStore(uint32_t Opcode,
-                                            uint32_t Ordinal,
-                                            IRNode **NewIR) override;
+                                            uint32_t Ordinal) override;
 
   // Remove all IRNodes from block (for verification error processing.)
-  void clearCurrentBlock(IRNode **NewIR) override {
+  void clearCurrentBlock() override {
     throw NotYetImplementedException("clearCurrentBlock");
   };
 
@@ -694,9 +671,7 @@ public:
     throw NotYetImplementedException("findTryRegionEndOfClauses");
   };
 
-  bool isCall(IRNode **NewIR) override {
-    throw NotYetImplementedException("isCall");
-  };
+  bool isCall() override { throw NotYetImplementedException("isCall"); };
   bool isRegionStartBlock(FlowGraphNode *Fg) override {
     throw NotYetImplementedException("isRegionStartBlock");
   };
@@ -707,7 +682,7 @@ public:
   // Create a symbol node that will be used to represent the stack-incoming
   // exception object
   // upon entry to funclets.
-  IRNode *makeExceptionObject(IRNode **NewIR) override {
+  IRNode *makeExceptionObject() override {
     throw NotYetImplementedException("makeExceptionObject");
   };
 
@@ -717,65 +692,60 @@ public:
 
   // Asks GenIR to make operand value accessible by address, and return a node
   // that references the incoming operand by address.
-  IRNode *addressOfLeaf(IRNode *Leaf, IRNode **NewIR) override;
-  IRNode *addressOfValue(IRNode *Leaf, IRNode **NewIR) override;
+  IRNode *addressOfLeaf(IRNode *Leaf) override;
+  IRNode *addressOfValue(IRNode *Leaf) override;
 
   // Helper callback used by rdrCall to emit call code.
   IRNode *genCall(ReaderCallTargetData *CallTargetInfo, CallArgTriple *ArgArray,
-                  uint32_t NumArgs, IRNode **CallNode,
-                  IRNode **NewIR) override;
+                  uint32_t NumArgs, IRNode **CallNode) override;
 
   bool canMakeDirectCall(ReaderCallTargetData *CallTargetData) override;
 
   // Generate call to helper
-  IRNode *callHelper(CorInfoHelpFunc HelperID, IRNode *Dst, IRNode **NewIR,
-                     IRNode *Arg1 = NULL, IRNode *Arg2 = NULL,
-                     IRNode *Arg3 = NULL, IRNode *Arg4 = NULL,
+  IRNode *callHelper(CorInfoHelpFunc HelperID, IRNode *Dst, IRNode *Arg1 = NULL,
+                     IRNode *Arg2 = NULL, IRNode *Arg3 = NULL,
+                     IRNode *Arg4 = NULL,
                      ReaderAlignType Alignment = Reader_AlignUnknown,
                      bool IsVolatile = false, bool NoCtor = false,
                      bool CanMoveUp = false) override;
 
   // Generate call to helper
   IRNode *callHelperImpl(CorInfoHelpFunc HelperID, llvm::Type *ReturnType,
-                         IRNode **NewIR, IRNode *Arg1 = NULL,
-                         IRNode *Arg2 = NULL, IRNode *Arg3 = NULL,
-                         IRNode *Arg4 = NULL,
+                         IRNode *Arg1 = NULL, IRNode *Arg2 = NULL,
+                         IRNode *Arg3 = NULL, IRNode *Arg4 = NULL,
                          ReaderAlignType Alignment = Reader_AlignUnknown,
                          bool IsVolatile = false, bool NoCtor = false,
                          bool CanMoveUp = false);
 
   // Generate special generics helper that might need to insert flow
   IRNode *callRuntimeHandleHelper(CorInfoHelpFunc Helper, IRNode *Arg1,
-                                  IRNode *Arg2, IRNode *NullCheckArg,
-                                  IRNode **NewIR) override {
+                                  IRNode *Arg2, IRNode *NullCheckArg) override {
     throw NotYetImplementedException("callRuntimeHandleHelper");
   };
 
-  IRNode *convertToHelperArgumentType(IRNode *Opr, uint32_t DestinationSize,
-                                      IRNode **NewIR) override {
+  IRNode *convertToHelperArgumentType(IRNode *Opr,
+                                      uint32_t DestinationSize) override {
     throw NotYetImplementedException("convertToHelperArgumentType");
   };
 
-  IRNode *genNullCheck(IRNode *Node, IRNode **NewIR) override;
+  IRNode *genNullCheck(IRNode *Node) override;
 
   void
   createSym(uint32_t Num, bool IsAuto, CorInfoType CorType,
             CORINFO_CLASS_HANDLE Class, bool IsPinned,
             ReaderSpecialSymbolType SymType = Reader_NotSpecialSymbol) override;
 
-  IRNode *derefAddress(IRNode *Address, bool DstIsGCPtr, bool IsConst,
-                       IRNode **NewIR) override;
+  IRNode *derefAddress(IRNode *Address, bool DstIsGCPtr, bool IsConst) override;
 
-  IRNode *conditionalDerefAddress(IRNode *Address, IRNode **NewIR) override {
+  IRNode *conditionalDerefAddress(IRNode *Address) override {
     throw NotYetImplementedException("conditionalDerefAddress");
   };
 
-  IRNode *getHelperCallAddress(CorInfoHelpFunc HelperId,
-                               IRNode **NewIR) override;
+  IRNode *getHelperCallAddress(CorInfoHelpFunc HelperId) override;
 
   IRNode *handleToIRNode(mdToken Token, void *EmbedHandle, void *RealHandle,
                          bool IsIndirect, bool IsReadOnly, bool IsRelocatable,
-                         bool IsCallTarget, IRNode **NewIR,
+                         bool IsCallTarget,
                          bool IsFrozenObject = false) override;
 
   // Create an operand that will be used to hold a pointer.
@@ -797,8 +767,7 @@ public:
   // Called once region tree has been built.
   void setEHInfo(EHRegion *EhRegionTree, EHRegionList *EhRegionList) override;
 
-  void setSequencePoint(uint32_t, ICorDebugInfo::SourceTypes,
-                        IRNode **NewIR) override {
+  void setSequencePoint(uint32_t, ICorDebugInfo::SourceTypes) override {
     throw NotYetImplementedException("setSequencePoint");
   };
   bool needSequencePoints() override;
@@ -810,24 +779,23 @@ public:
 
   // vararg
   bool callIsCorVarArgs(IRNode *CallNode);
-  void canonVarargsCall(IRNode *CallNode, ReaderCallTargetData *CallTargetInfo,
-                        IRNode **NewIR) {
+  void canonVarargsCall(IRNode *CallNode,
+                        ReaderCallTargetData *CallTargetInfo) {
     throw NotYetImplementedException("canonVarargsCall");
   };
 
   // newobj
   bool canonNewObjCall(IRNode *CallNode, ReaderCallTargetData *CallTargetData,
-                       IRNode **OutResult, IRNode **NewIR);
+                       IRNode **OutResult);
   void canonNewArrayCall(IRNode *CallNode, ReaderCallTargetData *CallTargetData,
-                         IRNode **OutResult, IRNode **NewIR);
+                         IRNode **OutResult);
 #endif
 
   // Used to expand multidimensional array access intrinsics
-  bool arrayGet(CORINFO_SIG_INFO *Sig, IRNode **RetVal,
-                IRNode **NewIR) override {
+  bool arrayGet(CORINFO_SIG_INFO *Sig, IRNode **RetVal) override {
     throw NotYetImplementedException("arrayGet");
   };
-  bool arraySet(CORINFO_SIG_INFO *Sig, IRNode **NewIR) override {
+  bool arraySet(CORINFO_SIG_INFO *Sig) override {
     throw NotYetImplementedException("arraySet");
   };
 
@@ -835,7 +803,7 @@ public:
   void dbDumpFunction(void) override {
     throw NotYetImplementedException("dbDumpFunction");
   };
-  void dbPrintIRNode(IRNode *NewIR) override { NewIR->dump(); };
+  void dbPrintIRNode(IRNode *Instr) override { Instr->dump(); };
   void dbPrintFGNode(FlowGraphNode *Fg) override {
     throw NotYetImplementedException("dbPrintFGNode");
   };
@@ -874,12 +842,11 @@ private:
   IRNode *genPointerSub(IRNode *Arg1, IRNode *Arg2);
   IRNode *getFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
                           CORINFO_FIELD_INFO *FieldInfo, IRNode *Obj,
-                          bool MustNullCheck, IRNode **NewIR);
+                          bool MustNullCheck);
 
   IRNode *simpleFieldAddress(IRNode *BaseAddress,
                              CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                             CORINFO_FIELD_INFO *FieldInfo,
-                             IRNode **NewIR) override;
+                             CORINFO_FIELD_INFO *FieldInfo) override;
 
   IRNode *getPrimitiveAddress(IRNode *Addr, CorInfoType CorInfoType,
                               ReaderAlignType Alignment, uint32_t *Align);
@@ -931,7 +898,7 @@ private:
   uint32_t argIndexToArgOrdinal(uint32_t ArgIndex);
 
   void makeStore(llvm::Type *Ty, llvm::Value *Address,
-                 llvm::Value *ValueToStore, bool IsVolatile, IRNode **NewIR);
+                 llvm::Value *ValueToStore, bool IsVolatile);
 
 private:
   LLILCJitContext *JitContext;


### PR DESCRIPTION
Remove the IRNode **NewIR parameter that many reader methods had.  It was
a vestige of an explicit insertion point threading that has been
superceded by the use of the LLVMBuilder's insertion point.

Verified no IR diffs.

Fixes #246
