### PR TITLE
Fix path to llilcBuild if not specified

### DIFF
--- a/utils/ccformat.py
+++ b/utils/ccformat.py
@@ -41,7 +41,11 @@ def runTidy(args):
       return 1
 
     llilcSrc = expandPath(args.llilc_source)
-    llilcBuild = expandPath(args.llilc_build)
+    llilcBuild = ""
+    if args.llilc_build != None:
+      llilcBuild = expandPath(args.llilc_build)
+    else:
+      llilcBuild = expandPath(os.path.join(args.llvm_build, "tools", "llilc"))
     llilcLib = os.path.join(llilcSrc, "lib")
     llilcInc = os.path.join(llilcSrc, "include")
 


### PR DESCRIPTION
If args.llvm_build is specified and llilcBuild and LLVMBUILD are not,
the path specified by args.llilc_build is None. This fix defaults
llilcBuild to args.llvm_build\tools\llilc if llilcBuild is None.
