### PR TITLE
Define __stdcall in LLILCPal when building with Clang on Windows

### DIFF
--- a/include/Pal/LLILCPal.h
+++ b/include/Pal/LLILCPal.h
@@ -19,7 +19,7 @@
 //
 // __stdcall is X86 specific. MSVC ignores the attribute on other architectures,
 // whereas other compilers complain about the ignored attribute.
-#if !defined(_MSC_VER) && !defined(_HOST_X86_)
+#if (!defined(_MSC_VER) || defined(__clang__)) && !defined(_HOST_X86_)
 #define __stdcall
 #endif // MSC_VER && _HOST_X86
 


### PR DESCRIPTION
Clang on Windows defines the _MSC_VER constant, but does not mimic the
MSVC behavior for defining __stdcall on non-x86 architectures.
This results in unknown-attribute warnings when compiling LLILC code
using Clang on Windows.

Therefore, this change circumvents the problem by defining __stdcall
when building for Clang.
