### PR TITLE
Allow user control whether to update test assets

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -72,7 +72,8 @@
 [CmdletBinding()]
 Param(
    [string]$Arch="x64",
-   [string]$Build="Debug"
+   [string]$Build="Debug",
+   [switch]$NoTestUpdate
 )
 
 # -------------------------------------------------------------------------
@@ -420,7 +421,9 @@ function CompleteEnvInit
 
   CreateLLVMBuildDirectory
 
-  GetCLRTestAssets
+  if (!$NoTestUpdate) {
+    GetCLRTestAssets
+  }
     
   NuGetCLR
 }


### PR DESCRIPTION
Give user a control whether to update test assets every time
when the script starts. In some cases, user does not want to
automatically update the test assets every time. By default,
the test assets update is on every time. To throttle that,
call the script with swith -NoTestUpdate, no value is needed
to pass into this parameter. It will be $True for a switch.
