### PR TITLE
Fix in-tree builds

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -756,14 +756,15 @@ function Global:Build([string]$Build="Debug")
 {
   $OutOfTree = Test-Path Env:\LLILCSOURCE
 
-  $LLILCBuild = LLILCBuild
   $TempBat = Join-Path $Env:TEMP "buildllilc.bat"
   $File = "$Env:VS120COMNTOOLS\..\..\VC\vcvarsall.bat"
 
   if ($OutOfTree) {
+    $LLILCBuild = LLILCBuild
     $WhatToBuild = "$LLILCBuild\LLILC.sln"
   }
   else {
+    $LLVMBuild = LLVMBuild
     $WhatToBuild = "/Project llilcjit $LLVMBuild\LLVM.sln"
   }
 


### PR DESCRIPTION
Define $LLVMBuild variable before referencing it in Build function (otherwise we try to build '\LLVM.sln', which likely doesn't exist).
Don't invoke LLILCBuild function from Build unless it will be used.
