### PR TITLE
Work on the entryLabel NYI failures

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -845,9 +845,18 @@ public:
 
   FlowGraphNode *CurrentFgNode;
 
-  bool HasLocAlloc;
-  uint32_t CurrInstrOffset; // current instruction IL offset
-  uint32_t NextInstrOffset; // next instruction IL offset
+  /// True if this method contains the 'localloc' MSIL opcode.
+  bool HasLocAlloc;                          
+
+  /// True if the client has optimistically transformed tail.
+  /// recursion into a branch.
+  bool HasOptimisticTailRecursionTransform;
+
+  /// The current instruction's IL offset.
+  uint32_t CurrInstrOffset;
+
+  /// The next instruction's IL offset.
+  uint32_t NextInstrOffset;
 
 private:
   // Private data (not available to derived client class)

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -2059,29 +2059,13 @@ void ReaderBase::setupBlockForEH() {
 }
 
 void ReaderBase::fgFixRecursiveEdges(FlowGraphNode *HeadBlock) {
-  FlowGraphNode *Block, *FallThroughBlock;
-  IRNode *BranchNode, *LabelNode;
-  bool HasFallThrough;
-
-  HasFallThrough = false;
-  FallThroughBlock = nullptr;
-
   // As a special case, localloc is incompatible with the recursive
   // tail call optimization, and any branches that we initially set up
   // for the recursive tail call (before we knew about the localloc)
   // should instead be re-pointed at the fall-through (for tail.call)
   // or the function exit (for jmp).
-  if (HasLocAlloc) {
-    // Revert all recursive branch IR.
-    // For a tail.call, this involves changing to fall-through.
-    // For a jmp, this involves changing to point at the exit label.
-    BranchList *BranchList, *BranchListNext;
-    for (BranchList = fgGetLabelBranchList(entryLabel()); BranchList != nullptr;
-         BranchList = BranchListNext) {
-      BranchListNext = branchListGetNext(BranchList);
-      BranchNode = branchListGetIRNode(BranchList);
-      fgRevertRecursiveBranch(BranchNode);
-    }
+  if (HasLocAlloc && HasOptimisticTailRecursionTransform) {
+    throw NotYetImplementedException("undo optimistic recursive tail calls");
   }
 }
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -6585,7 +6585,7 @@ ThrowNullRef18:                                   ; preds = %70
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[entryLabel]
+Failed to read Path.NormalizePath[BinaryOp Overflow]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Successfully read String.TrimHelper
 
@@ -7562,7 +7562,7 @@ ThrowNullRef4:                                    ; preds = %5
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
-Failed to read PathHelper.GetFullPathName[entryLabel]
+Failed to read PathHelper.GetFullPathName[BinaryOp Overflow]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit


### PR DESCRIPTION
`entryLabel` was used to enumerate the optimistic tail recursion branches. Since we don't do this optimization we don't need to ask for the entry label. I added a flag `HasOptimisticTailRecursionTransform` to `ReaderBase` that the client can set if such branches are added, and simplified `fgFixRecursiveEdges` to fail only if it sees that flag and `HasLocAlloc`.

Net result is that the two cases that failed with this NYI -- Path.NormalizePath and PathHelper.GetFullPathName -- now fail handling mul.ovf, and those mul's feed locallocs. So no net gain on methods passing but we gain bit more clarity on what it will take to get them handled properly.
