### PR TITLE
Add missing cases for CORINFO_TYPE_CLASS

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1400,6 +1400,7 @@ uint32_t GenIR::stackSize(CorInfoType CorType) {
   case CorInfoType::CORINFO_TYPE_NATIVEUINT:
   case CorInfoType::CORINFO_TYPE_PTR:
   case CorInfoType::CORINFO_TYPE_BYREF:
+  case CorInfoType::CORINFO_TYPE_CLASS:
     return TargetPointerSizeInBits;
 
   default:
@@ -1436,6 +1437,7 @@ uint32_t GenIR::size(CorInfoType CorType) {
   case CorInfoType::CORINFO_TYPE_NATIVEUINT:
   case CorInfoType::CORINFO_TYPE_PTR:
   case CorInfoType::CORINFO_TYPE_BYREF:
+  case CorInfoType::CORINFO_TYPE_CLASS:
     return TargetPointerSizeInBits;
 
   default:
@@ -1459,6 +1461,7 @@ bool GenIR::isSigned(CorInfoType CorType) {
   case CorInfoType::CORINFO_TYPE_NATIVEUINT:
   case CorInfoType::CORINFO_TYPE_PTR:
   case CorInfoType::CORINFO_TYPE_BYREF:
+  case CorInfoType::CORINFO_TYPE_CLASS:
     return false;
 
   case CorInfoType::CORINFO_TYPE_BYTE:


### PR DESCRIPTION
Add code to get size, stackSize, and signedness for object references.

Verified no IR diffs.
Needed to unblock #257.
