### PR TITLE
Add missing case to fgSplitBlock

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1705,7 +1705,16 @@ FlowGraphNode *GenIR::fgSplitBlock(FlowGraphNode *Block, IRNode *Node) {
       BranchInst::Create(NewBlock, TheBasicBlock);
     }
   } else {
-    NewBlock = TheBasicBlock->splitBasicBlock(Inst);
+    if (TheBasicBlock->getTerminator() != nullptr) {
+      NewBlock = TheBasicBlock->splitBasicBlock(Inst);
+    } else {
+      NewBlock = BasicBlock::Create(*JitContext->LLVMContext, "", Function,
+                                    TheBasicBlock->getNextNode());
+      NewBlock->getInstList().splice(NewBlock->end(),
+                                     TheBasicBlock->getInstList(), Inst,
+                                     TheBasicBlock->end());
+      BranchInst::Create(NewBlock, TheBasicBlock);
+    }
   }
   return (FlowGraphNode *)NewBlock;
 }


### PR DESCRIPTION
Handle the case that a block has no terminator but does have one or more
instructions after the split point.  This can happen when inserting a null
check during the post-processing of a newobj (which generates the call and
then rewinds the insert point to do the post-processing which inserts the
null check) in a block that ends with a return (and thus doesn't get a
terminator in the first pass).

Verified no IR diffs.
Needed to unblock #257.
